### PR TITLE
Foodモデル, Foodsテーブル作成

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,5 @@
 class Category < ApplicationRecord
+  has_many :foods
+
   validates :name, presence: true
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,7 +1,6 @@
 class Food < ApplicationRecord
   belongs_to :category
   belongs_to :user, optional: true
-  
   validates :name, presence: true
   validates :quantity, presence: true
   validates :unit, presence: true
@@ -17,15 +16,13 @@ class Food < ApplicationRecord
       errors.add(:name, "すでに登録している名前は使用できません")
     end
   end
-  
   # ユーザーが食材を追加する際に既にデフォルト食材名として使用してた場合は登録不可
   # ユーザーが既に登録した食材名は使用できない
   def check_same_name_food
     if user_id.present? && Food.exists?(name: name, user_id: nil)
       errors.add(:name, "デフォルトで登録されている名前は使用できません")
     end
-      
-    if user_id.present? && Food.where(name: name, user_id: user.id).    where.not(id: self.id).exists? 
+    if user_id.present? && Food.where(name: name, user_id: user.id).    where.not(id: self.id).exists?
       errors.add(:name, "すでに登録している名前は使用できません")
     end
   end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,0 +1,32 @@
+class Food < ApplicationRecord
+  belongs_to :category
+  belongs_to :user, optional: true
+  
+  validates :name, presence: true
+  validates :quantity, presence: true
+  validates :unit, presence: true
+  validate :check_default_food
+  validate :check_same_name_food
+
+  private
+
+  # デフォルト食材が既にデフォルト食材名として登録されていた場合は登録不可
+  # 管理画面でデフォルト食材を作成・編集する際に有効
+  def check_default_food
+    if user_id.nil? && Food.where(name: name, user_id: nil).where.not(id: self.id).exists?
+      errors.add(:name, "すでに登録している名前は使用できません")
+    end
+  end
+  
+  # ユーザーが食材を追加する際に既にデフォルト食材名として使用してた場合は登録不可
+  # ユーザーが既に登録した食材名は使用できない
+  def check_same_name_food
+    if user_id.present? && Food.exists?(name: name, user_id: nil)
+      errors.add(:name, "デフォルトで登録されている名前は使用できません")
+    end
+      
+    if user_id.present? && Food.where(name: name, user_id: user.id).    where.not(id: self.id).exists? 
+      errors.add(:name, "すでに登録している名前は使用できません")
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  has_many :foods, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/account/passwords/edit.html.erb
+++ b/app/views/account/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "account_modal" do %>
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
-    <div data-controller="account-modal" data-account-modal-target="passwordModal" class="bg-white p-6 rounded shadow-md w-3/5 max-w-xl">
+    <div data-controller="account-modal" data-account-modal-target="passwordModal" class="bg-white p-6 rounded shadow-md w-full max-w-xl">
       <div class="text-center">
         <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl"><%= t('.password_edit') %></h1>
       </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "account_modal" do %>
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
-    <div data-controller="account-modal" data-account-modal-target="userModal" class="bg-white p-6 rounded shadow-md w-3/5 max-w-xl">
+    <div data-controller="account-modal" data-account-modal-target="userModal" class="bg-white p-6 rounded shadow-md w-full max-w-xl">
       <div class="text-center">
         <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl"><%= t('.user_profile_edit') %></h1>
       </div>

--- a/db/migrate/20250714155454_create_foods.rb
+++ b/db/migrate/20250714155454_create_foods.rb
@@ -1,0 +1,19 @@
+class CreateFoods < ActiveRecord::Migration[7.2]
+  def change
+    create_table :foods do |t|
+      t.references :user, foreign_key: true
+      t.references :category, foreign_key: true, null: false
+      t.string :name, null: false
+      t.integer :quantity, null: false
+      t.string :unit, null: false
+      t.integer :default_deadline
+      t.string :food_image
+
+      t.timestamps
+    end
+
+    add_index :foods, [:category_id, :name]
+    add_index :foods, [:user_id, :name], unique: true
+    add_index :foods, :name, unique: true, where: "user_id IS NULL"
+  end
+end

--- a/db/migrate/20250714155454_create_foods.rb
+++ b/db/migrate/20250714155454_create_foods.rb
@@ -12,8 +12,8 @@ class CreateFoods < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :foods, [:category_id, :name]
-    add_index :foods, [:user_id, :name], unique: true
+    add_index :foods, [ :category_id, :name ]
+    add_index :foods, [ :user_id, :name ], unique: true
     add_index :foods, :name, unique: true, where: "user_id IS NULL"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_14_100426) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_14_155454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,23 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_100426) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "foods", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "category_id", null: false
+    t.string "name", null: false
+    t.integer "quantity", null: false
+    t.string "unit", null: false
+    t.integer "default_deadline"
+    t.string "food_image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id", "name"], name: "index_foods_on_category_id_and_name"
+    t.index ["category_id"], name: "index_foods_on_category_id"
+    t.index ["name"], name: "index_foods_on_name", unique: true, where: "(user_id IS NULL)"
+    t.index ["user_id", "name"], name: "index_foods_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_foods_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -32,4 +49,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_14_100426) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "foods", "categories"
+  add_foreign_key "foods", "users"
 end

--- a/test/fixtures/foods.yml
+++ b/test/fixtures/foods.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  quantity: 1
+  unit: MyString
+  default_deadline: 1
+  food_image: MyString
+
+two:
+  name: MyString
+  quantity: 1
+  unit: MyString
+  default_deadline: 1
+  food_image: MyString

--- a/test/models/food_test.rb
+++ b/test/models/food_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class FoodTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Foodモデル作成
- Foodsテーブル作成
- Userモデル, Categoryモデル, Foodモデルにリレーション定義
- Foodモデルにバリデーション定義

## 概要
- UserモデルとFoodモデルは`1対多`の関係
- CategoryモデルとFoodモデルは`1対多`の関係
- Foodモデルのバリデーション
  - `name`カラム, `quantity`カラム, `unit`カラムは必須(`presence: true`)
  - デフォルト食材が既にデフォルト食材名として登録されていた場合は登録不可
  　(管理画面でデフォルト食材を作成・編集する際に有効)
  - ユーザーが食材を追加する際に既にデフォルト食材名として使用してた場合は登録不可
  - ユーザーが既に登録した食材名は使用できない
 
#### Issue番号
closed #12 