### PR TITLE
ユーザーが登録した食材リストの編集、削除機能

### DIFF
--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -15,7 +15,7 @@ class FoodsController < ApplicationController
   def create
     @food = current_user.foods.build(food_params)
     if @food.save
-      redirect_to foods_path(category_id: @food.category_id), notice: "食品リストを追加しました"
+      redirect_to foods_path(category_id: @food.category_id), notice: t('helpers.flash_messages.foods_list_add')
     else
       render :new, status: :unprocessable_entity
     end
@@ -25,7 +25,7 @@ class FoodsController < ApplicationController
 
   def update
     if @food.update(food_params)
-      redirect_to foods_path(category_id: @food.category_id), notice: "食品リストを更新しました"
+      redirect_to foods_path(category_id: @food.category_id), notice: t('helpers.flash_messages.foods_list_update')
     else
       render :edit, status: :unprocessable_entity
     end
@@ -33,7 +33,8 @@ class FoodsController < ApplicationController
 
   def destroy
     @food.destroy!
-    redirect_to foods_path(category_id: @food.category_id), notice: "食品リストから削除しました", status: :see_other
+    @foods = current_user.foods.where(category_id: @food.category_id)
+    flash.now[:notice] = t('helpers.flash_messages.foods_list_delete')
   end
 
   private

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -1,6 +1,7 @@
 class FoodsController < ApplicationController
   before_action :authenticate_user!
   before_action :category_id_present?, only: %i[ index ]
+  before_action :find_user_food, only: %i[ edit update destroy ]
 
   def index
     @categories = Category.order(id: :asc)
@@ -14,10 +15,25 @@ class FoodsController < ApplicationController
   def create
     @food = current_user.foods.build(food_params)
     if @food.save
-      redirect_to foods_path, notice: "食品リストを追加しました"
+      redirect_to foods_path(category_id: @food.category_id), notice: "食品リストを追加しました"
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def edit; end
+
+  def update
+    if @food.update(food_params)
+      redirect_to foods_path(category_id: @food.category_id), notice: "食品リストを更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @food.destroy!
+    redirect_to foods_path(category_id: @food.category_id), notice: "食品リストから削除しました", status: :see_other
   end
 
   private
@@ -30,5 +46,9 @@ class FoodsController < ApplicationController
     if params[:category_id].blank?
       redirect_to foods_path(category_id: 1)
     end
+  end
+
+  def find_user_food
+    @food = current_user.foods.find(params[:id])
   end
 end

--- a/app/controllers/foods_controller.rb
+++ b/app/controllers/foods_controller.rb
@@ -15,7 +15,7 @@ class FoodsController < ApplicationController
   def create
     @food = current_user.foods.build(food_params)
     if @food.save
-      redirect_to foods_path(category_id: @food.category_id), notice: t('helpers.flash_messages.foods_list_add')
+      redirect_to foods_path(category_id: @food.category_id), notice: t("helpers.flash_messages.foods_list_add")
     else
       render :new, status: :unprocessable_entity
     end
@@ -25,7 +25,7 @@ class FoodsController < ApplicationController
 
   def update
     if @food.update(food_params)
-      redirect_to foods_path(category_id: @food.category_id), notice: t('helpers.flash_messages.foods_list_update')
+      redirect_to foods_path(category_id: @food.category_id), notice: t("helpers.flash_messages.foods_list_update")
     else
       render :edit, status: :unprocessable_entity
     end
@@ -34,7 +34,7 @@ class FoodsController < ApplicationController
   def destroy
     @food.destroy!
     @foods = current_user.foods.where(category_id: @food.category_id)
-    flash.now[:notice] = t('helpers.flash_messages.foods_list_delete')
+    flash.now[:notice] = t("helpers.flash_messages.foods_list_delete")
   end
 
   private

--- a/app/javascript/controllers/foods_modal_controller.js
+++ b/app/javascript/controllers/foods_modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="foods-modal"
+export default class extends Controller {
+  static targets = [ "foodModal" ]
+
+  connect() {
+  }
+
+  closeFood(event){
+    if(event.detail.success){
+      this.foodModalTarget.classList.add("hidden")
+    }
+  }
+
+  closeFoodModal(){
+    this.foodModalTarget.classList.add("hidden")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,6 +7,9 @@ import { application } from "./application"
 import AccountModalController from "./account_modal_controller"
 application.register("account-modal", AccountModalController)
 
+import FoodsModalController from "./foods_modal_controller"
+application.register("foods-modal", FoodsModalController)
+
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 

--- a/app/views/foods/_foods_list.html.erb
+++ b/app/views/foods/_foods_list.html.erb
@@ -1,0 +1,30 @@
+<% foods.each do |food| %>
+  <div class="flex flex-col items-center space-y-2">
+    <%= turbo_frame_tag "food" do %>
+      <% if food.user_id == current_user.id %>
+        <%= turbo_frame_tag dom_id(food) do %>
+          <div class="text-center space-x-2">
+            <%= link_to edit_food_path(id: food.id), data: { turbo_frame: 'food' }, class: "inline-flex items-center space-x-1" do %>
+              <%= food.name %>
+              <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
+            <% end %>
+          </div>
+          <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
+            <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
+          </div>
+        <% end %>
+      <% else %>
+        <div class="text-center">
+          <%= food.name %>
+        </div>
+        <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
+          <% if food.food_image.attached? %>
+            <%= image_tag food.food_image.variant(resize_to_limit: [80, 80]) %>
+          <% else %>
+            <span class="text-xs text-gray-400"><%= t('.no_image') %></span>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: food do |f| %>
+<%= form_with(model: food, data: { turbo: false }) do |f| %>
   <%= render "shared/error_messages", object: f.object %>
     <div class="flex space-x-6">
       <div class="flex justify-center items-center">

--- a/app/views/foods/_form.html.erb
+++ b/app/views/foods/_form.html.erb
@@ -1,0 +1,46 @@
+<%= form_with model: food do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
+    <div class="flex space-x-6">
+      <div class="flex justify-center items-center">
+        <div class="w-50 h-50 rounded-full bg-gradient-to-br from-orange-200 to-green-100 flex items-center justify-center">
+          <i class="material-symbols-rounded !text-6xl" style="font-variation-settings: 'wght' 100;">washoku</i>
+        </div>
+      </div>
+      <div class="flex flex-col justify-center space-y-2">
+        <div>
+          <%= f.label :name, class: "text-sm font-medium text-gray-700" %>
+          <span class="text-red-500 font-normal text-sm">
+            <%= t('.required') %>
+          </span>
+          <%= f.text_field :name, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800"%>
+        </div>
+
+        <div>
+          <%= f.label :quantity, class: "text-sm font-medium text-gray-700" %>
+          <span class="text-red-500 font-normal text-sm">
+            <%= t('.required') %>
+          </span>
+          <%= f.text_field :quantity, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
+        </div>
+
+        <div>
+          <%= f.label :unit, class: "text-sm font-medium text-gray-700" %>
+          <span class="text-red-500 font-normal text-sm">
+            <%= t('.required') %>
+          </span>
+          <%= f.text_field :unit, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
+        </div>
+
+        <div>
+          <%= f.label :default_deadline, class: "block text-left text-sm font-medium text-gray-700" %>
+          <%= f.text_field :default_deadline, class: "w-1/2 ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
+          <span class="text-lg font-medium text-gray-700">
+            <%= t('.day') %>
+          </span>
+        </div>
+
+        <%= f.hidden_field :category_id %>
+      </div>
+    </div>
+    <%= f.submit nil, class: "w-full inline-block text-center mt-2 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %> 
+<% end %>

--- a/app/views/foods/destroy.turbo_stream.erb
+++ b/app/views/foods/destroy.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace "foods_list" do %>
+  <%= render "foods_list", foods: @foods %>
+<% end %>
+
+<%= turbo_stream.update "flash" do %>
+  <%= render "shared/flash_message" %>
+<% end %>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -1,0 +1,15 @@
+<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
+  <div class="bg-white p-6 rounded shadow-md w-full max-w-xl">
+    <div class="text-center">
+      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
+        <%= t('.title') %>
+      </h1>
+    </div>
+
+    <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
+      <%= render 'form', food: @food %>
+      <%= link_to t('.destroy'), food_path(id: @food.id), data:{ turbo_method: :delete, turbo_confirm: "食品リストから削除してよろしいですか" }, class: "w-full inline-block text-center mt-2 bg-sky-200 hover:bg-sky-300 text-sky-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+      <%= link_to t('.back'), foods_path(category_id: @food.category_id), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+    </div>
+  </div>
+</div>

--- a/app/views/foods/edit.html.erb
+++ b/app/views/foods/edit.html.erb
@@ -1,15 +1,19 @@
-<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
-  <div class="bg-white p-6 rounded shadow-md w-full max-w-xl">
-    <div class="text-center">
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
-        <%= t('.title') %>
-      </h1>
-    </div>
+<%= turbo_frame_tag "food" do %>
+  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
+    <div data-controller="foods-modal" data-foods-modal-target="foodModal" class="bg-white p-6 rounded shadow-md w-full max-w-xl">
+      <div class="text-center">
+        <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
+          <%= t('.title') %>
+        </h1>
+      </div>
 
-    <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
-      <%= render 'form', food: @food %>
-      <%= link_to t('.destroy'), food_path(id: @food.id), data:{ turbo_method: :delete, turbo_confirm: "食品リストから削除してよろしいですか" }, class: "w-full inline-block text-center mt-2 bg-sky-200 hover:bg-sky-300 text-sky-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
-      <%= link_to t('.back'), foods_path(category_id: @food.category_id), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+      <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
+        <%= render 'form', food: @food %>
+        <%= link_to t('.destroy'), food_path(id: @food.id), data:{ turbo_method: :delete, turbo_confirm: "食品リストから削除してよろしいですか" }, class: "w-full inline-block text-center mt-2 bg-sky-200 hover:bg-sky-300 text-sky-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+        <div data-action="turbo:submit-end->foods-modal#closeFoodModal">
+          <%= link_to t('.back'), foods_path(category_id: @food.category_id), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+        </div>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -13,9 +13,11 @@
             <% if food.user_id == current_user.id %>
               <div class="flex items-center space-x-2">
                 <%= food.name %>
-                <%= link_to "#" do %>
-                  <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
-                <% end %>
+                <div data-turbo="false">
+                  <%= link_to edit_food_path(id: food.id) do %>
+                    <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
+                  <% end %>
+                </div>
               </div>
               <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
                 <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
@@ -33,9 +35,9 @@
           </div>
         <% end %>
         <div data-turbo="false">
-        <%= link_to new_food_path(category_id: params[:category_id]), class: "bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center mt-8 border-2 border-gray-300" do %>
-          <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>          
-        <% end %>
+          <%= link_to new_food_path(category_id: params[:category_id]), class: "bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center mt-8 border-2 border-gray-300" do %>
+            <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>          
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/foods/index.html.erb
+++ b/app/views/foods/index.html.erb
@@ -5,40 +5,13 @@
         <%= t('.title') %>
       </h1>
     </div>
-    <%= render 'categories/category_nav', categories:@categories %>
+    <%= render 'categories/category_nav', categories: @categories %>
     <%= turbo_frame_tag "foods_list" do %>
       <div class="flex flex-wrap gap-4">
-        <% @foods.each do |food| %>
-          <div class="flex flex-col items-center space-y-2">
-            <% if food.user_id == current_user.id %>
-              <div class="flex items-center space-x-2">
-                <%= food.name %>
-                <div data-turbo="false">
-                  <%= link_to edit_food_path(id: food.id) do %>
-                    <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
-                  <% end %>
-                </div>
-              </div>
-              <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
-                <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
-              </div>
-            <% else %>
-              <div><%= food.name %></div>
-              <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
-                <% if food.food_image.attached? %>
-                  <%= image_tag food.food_image.variant(resize_to_limit: [80, 80]) %>
-                <% else %>
-                  <span class="text-xs text-gray-400"><%= t('.no_image') %></span>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
+        <%= render 'foods_list', foods: @foods %>
+        <%= link_to new_food_path(category_id: params[:category_id]), data: { turbo_frame: 'food' }, class: "bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center mt-6 border-2 border-gray-300" do %>
+          <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>          
         <% end %>
-        <div data-turbo="false">
-          <%= link_to new_food_path(category_id: params[:category_id]), class: "bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center mt-8 border-2 border-gray-300" do %>
-            <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>          
-          <% end %>
-        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -5,60 +5,11 @@
         <%= t('.title') %>
       </h1>
     </div>
-
     <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
-      <%= form_with(model: @food, html: { method: :post }) do |f| %>
-        <%= render "shared/error_messages", object: @food %>
-          <div class="flex space-x-6">
-            <div class="flex justify-center items-center">
-              <div class="w-50 h-50 rounded-full bg-gradient-to-br from-orange-200 to-green-100 flex items-center justify-center">
-                <i class="material-symbols-rounded !text-6xl" style="font-variation-settings: 'wght' 100;">washoku</i>
-              </div>
-            </div>
-
-            <div class="flex flex-col justify-center space-y-2">
-              <div>
-                <%= f.label :name, class: "text-sm font-medium text-gray-700" %>
-                <span class="text-red-500 font-normal text-sm">
-                  <%= t('.required') %>
-                </span>
-                <%= f.text_field :name, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800"%>
-              </div>
-
-              <div>
-                <%= f.label :quantity, class: "text-sm font-medium text-gray-700" %>
-                <span class="text-red-500 font-normal text-sm">
-                  <%= t('.required') %>
-                </span>
-                <%= f.text_field :quantity, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
-              </div>
-
-              <div>
-                <%= f.label :unit, class: "text-sm font-medium text-gray-700" %>
-                <span class="text-red-500 font-normal text-sm">
-                  <%= t('.required') %>
-                </span>
-                <%= f.text_field :unit, class: "w-full ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
-              </div>
-
-              <div>
-                <%= f.label :default_deadline, class: "block text-left text-sm font-medium text-gray-700" %>
-                <%= f.text_field :default_deadline, class: "w-1/2 ml-2 mb-2 rounded-xl border-2 border-gray-400 bg-white/80 px-3 py-2 text-gray-800" %>
-                <span class="text-lg font-medium text-gray-700">
-                  <%= t('.day') %>
-                </span>
-              </div>
-
-              <%= f.hidden_field :category_id %>
-            </div>
-          </div>
-        
-          <div class="space-y-2">
-            <%= f.submit t('.create'), class: "w-full mt-4 bg-orange-400 hover:bg-orange-500 text-white font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %> 
-            <%= link_to t('.back'), foods_path(category_id: params[:category_id]), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
-          </div>
-      <% end %>
+      <%= render 'form', food: @food %>
+      <div class="space-y-2">
+        <%= link_to t('.back'), foods_path(category_id: params[:category_id]), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+      </div>
     </div>
   </div>
 </div>
-

--- a/app/views/foods/new.html.erb
+++ b/app/views/foods/new.html.erb
@@ -1,15 +1,17 @@
-<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
-  <div class="bg-white p-6 rounded shadow-md w-full max-w-xl">
-    <div class="text-center">
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
-        <%= t('.title') %>
-      </h1>
-    </div>
-    <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
-      <%= render 'form', food: @food %>
-      <div class="space-y-2">
-        <%= link_to t('.back'), foods_path(category_id: params[:category_id]), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+<%= turbo_frame_tag "food" do %>
+  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
+    <div data-controller="foods-modal" data-foods-modal-target="foodModal" class="bg-white p-6 rounded shadow-md w-full max-w-xl">
+      <div class="text-center">
+        <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
+          <%= t('.title') %>
+        </h1>
+      </div>
+      <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 pt-4 p-8 shadow-lg border border-orange-100">
+        <%= render 'form', food: @food %>
+        <div class="space-y-2">
+          <%= link_to t('.back'), foods_path(category_id: params[:category_id]), class: "w-full inline-block text-center mt-2 bg-gray-200 hover:bg-gray-300 text-gray-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,9 @@
 
   <body class="min-h-screen flex flex-col bg-gradient-to-br from-orange-50 to-green-50">
       <%= render 'shared/header' %>
-      <%= render 'shared/flash_message' %>
+      <div id="flash">
+        <%= render 'shared/flash_message' %>
+      </div>
       <%= yield %>
       <% if user_signed_in? %>
         <%= render 'shared/footer' %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -4,6 +4,9 @@ ja:
       logged_in_user: すでにログインしています
       password_update: パスワードを変更しました
       user_profile_update: ユーザー情報を更新しました
+      foods_list_add: 食材リストを追加しました
+      foods_list_update: 食材リストを更新しました
+      foods_list_delete: 食材リストから削除しました
   header:
     login: ログイン
     app_name: FridgeBell

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -44,8 +44,12 @@ ja:
       no_image: 画像なし
     new: 
       title: 食材リスト追加
+      back: キャンセル
+    edit:
+      title: 食品リスト編集
+      destroy: 削除
+      back: キャンセル
+    form:
       required: 必須
       day: 日
-      create: 登録
-      back: キャンセル
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   namespace :account do
     resource :password, only: %i[edit update]
   end
-  resources :foods, only: %i[index new create]
+  resources :foods, only: %i[index new create edit update destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要
ユーザーが登録した食材リストの編集・削除機能追加

## 内容
- `foods`コントローラーに`edit`, `update`, `destroy`アクション追加
- `foods#new`と`foods#edit`の入力フォームを部分テンプレート(`_form.html.erb`)にまとめる
- リスト追加・編集画面はモーダル化
- 食品リストを部分テンプレート(`_foods_list.html.erb`)にまとめる
- 食材リスト削除機能は`Turbo Stream`で対応

#### ISSUE番号
closed #78 
