### PR TITLE
冷蔵庫内の食材を編集

### DIFF
--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -1,8 +1,10 @@
 class UserFoodsController < ApplicationController
   before_action :authenticate_user!
+  before_action :find_registered_user_food, only: %i[ edit update]
   def index
     @user_foods = current_user.user_foods.includes(:food).order(deadline_date: :asc)
   end
+
   def new
     @categories = Category.order(id: :asc)
     @foods = Food.where(category_id: params[:category_id]).order(name: :asc)
@@ -20,9 +22,23 @@ class UserFoodsController < ApplicationController
     end
   end
 
+  def edit; end
+
+  def update
+    if @user_food.update(user_foods_params)
+      redirect_to user_foods_path, notice: "冷蔵庫内の食材情報を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def user_foods_params
     params.require(:user_food).permit(:food_id, :quantity, :deadline_date, :mini_memo)
+  end
+
+  def find_registered_user_food
+    @user_food = current_user.user_foods.find(params[:id])
   end
 end

--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -26,7 +26,11 @@ class UserFoodsController < ApplicationController
 
   def update
     if @user_food.update(user_foods_params)
-      redirect_to user_foods_path, notice: "冷蔵庫内の食材情報を更新しました"
+      flash[:notice] = "冷蔵庫内の食材情報を更新しました"
+      render turbo_stream: [
+        turbo_stream.replace(@user_food),
+        turbo_stream.update("flash", partial: "shared/flash_message")
+      ]
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,5 +13,8 @@ application.register("foods-modal", FoodsModalController)
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
 
+import UserFoodModalController from "./user_food_modal_controller"
+application.register("user-food-modal", UserFoodModalController)
+
 import UserMenuController from "./user_menu_controller"
 application.register("user-menu", UserMenuController)

--- a/app/javascript/controllers/user_food_modal_controller.js
+++ b/app/javascript/controllers/user_food_modal_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="user-food-modal"
+export default class extends Controller {
+  static targets = ["userFoodModal"]
+
+  connect() {
+  }
+
+  close(event){
+    if(event.detail.success){
+      this.userFoodModalTarget.classList.add("hidden");
+    }
+  }
+
+  closeModal(){
+    this.userFoodModalTarget.classList.add("hidden");
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,5 +31,6 @@
         <%= render 'shared/before_login_footer' %>
       <% end %>
       <%= turbo_frame_tag 'account_modal' %>
+      <%= turbo_frame_tag 'user_food_modal' %>
   </body>
 </html>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,5 +1,5 @@
 <div class="w-full">
-  <div class="w-3/5 mx-auto pt-5">
+  <div class="w-4/5 mx-auto pt-5">
     <% flash.each do |message_type, message| %>
       <% case message_type.to_sym %>
       <% when :notice %>

--- a/app/views/user_foods/_user_food.html.erb
+++ b/app/views/user_foods/_user_food.html.erb
@@ -1,0 +1,48 @@
+<%= turbo_frame_tag user_food do %>
+  <% remaining_days = (user_food.deadline_date - Date.today).to_i %>
+  <% bg_color = case remaining_days
+                when ...0
+                  "bg-gray-200"
+                when 0..2
+                  "bg-red-200"
+                when 3..5
+                  "bg-yellow-200"
+                else
+                  "bg-green-200"
+                end %>
+  <% deadline_text = remaining_days %>
+  <div class="flex items-center rounded-xl shadow-md border p-4 mb-4 space-x-4 <%= bg_color %>">
+
+    <div class="flex-shrink-0 w-25 h-25 rounded-full flex items-center justify-center overflow-hidden">
+      <%= image_tag user_food.food.food_image.variant(resize_to_limit: [80, 80]) %>
+    </div>
+
+    <div class="flex flex-col flex-1 self-center text-sm space-y-1">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-start md:gap-4">
+        <div class="font-bold text-lg"><%= user_food.food.name %></div>
+        <% if deadline_text < 0 %>
+          <div class="flex items-center space-x-1 font-bold text-lg text-red-500">
+            <span>お早めにどうぞ</span>
+            <%= heroicon "exclamation-triangle", options: { class: "w-5 h-5" } %>
+          </div>
+        <% else %>
+          <div class="font-bold text-lg text-red-500">あと<%= deadline_text %>日</div>
+        <% end %>
+      </div>
+      <div class="font-semibold">期限: <%= user_food.deadline_date %></div>
+      <div>数量: <%= user_food.quantity %><%= user_food.food.unit %></div>
+      <% if user_food.mini_memo.present? %>
+        <div class="text-gray-700">メモ: <%= user_food.mini_memo %></div>
+      <% end %>
+    </div>
+
+    <div class="flex flex-col items-center justify-center space-y-4">
+      <%= link_to edit_user_food_path(id: user_food.id), class: "text-gray-500 hover:text-blue-600", data: { turbo_frame: 'user_food_modal' } do %>
+        <%= heroicon "pencil", options: { class: "w-6 h-6"} %>
+      <% end %>
+      <%= link_to user_food_path(id: user_food.id), data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか" }, class: "text-gray-500 hover:text-red-600" do %>
+        <%= heroicon "trash", options: { class: "w-6 h-6"} %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/user_foods/edit.html.erb
+++ b/app/views/user_foods/edit.html.erb
@@ -1,15 +1,16 @@
-<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
-  <div class="bg-white p-6 rounded shadow-md w-full md:max-w-xl max-w-md">
-    <div class="text-center">
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
-      冷蔵庫内の食材を修正
-      </h1>
-    </div>
+<%= turbo_frame_tag "user_food_modal" do %>
+  <div data-controller="user-food-modal" data-user-food-modal-target="userFoodModal" class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
+    <div class="bg-white p-6 rounded shadow-md w-full md:max-w-xl max-w-md">
+      <div class="text-center">
+        <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
+        冷蔵庫内の食材を修正
+        </h1>
+      </div>
 
-    <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 p-8 shadow-lg border border-orange-100">
-      <%= form_with(model: @user_food, data: { turbo: false }) do |f| %>
-      <%= render "shared/error_messages", object: f.object %>
-        <div class="flex items-center justify-center gap-4 mb-6">
+      <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 p-8 shadow-lg border border-orange-100">
+        <%= form_with(model: @user_food, data: { action: "turbo:submit-end->user-food-modal#close" }) do |f| %>
+        <%= render "shared/error_messages", object: f.object %>
+          <div class="flex items-center justify-center gap-4 mb-6">
             <%= image_tag @user_food.food.food_image.variant(resize_to_limit: [80, 80]) %>
             <div>
               <h3 class="text-lg font-medium text-gray-900"><%= @user_food.food.name %></h3>
@@ -19,23 +20,17 @@
             </div>
           </div>
 
-          <div class="space-y-5 text-sm">
+          <div class="space-y-2 text-sm">
             <div class="flex flex-wrap md:flex-nowrap gap-4 items-start">
               <div class="w-20">
                 <%= f.label :quantity, class: "block font-medium text-gray-700 mb-1" %>
-                <%= f.number_field :quantity, min: 1, class: "w-full border border-gray-400 rounded px-4 py-2 text-center" %>
+                <%= f.number_field :quantity, min: 1, class: "w-full border border-gray-400 rounded px-2 py-2 text-center" %>
               </div>
               <div class="flex-1">
                 <%= f.label :deadline_date, class: "block font-medium text-gray-700 mb-1" %>
-                <div class="flex space-x-2">
+                <div class="flex">
                   <div class="border border-gray-400 rounded px-2 py-2 text-sm">
-                    <%= select_year(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "1i", start_year: Date.today.year, end_year: Date.today.year + 5, class: "outline-none") %>
-                  </div>
-                  <div class="border border-gray-400 rounded px-2 py-2 text-sm">
-                    <%= select_month(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "2i", class: "outline-none") %>
-                  </div>
-                  <div class="border border-gray-400 rounded px-2 py-2 text-sm">
-                    <%= select_day(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "3i", class: "outline-none") %>
+                    <%= f.date_select :deadline_date,  { start_year: Date.today.year, end_year: Date.today.year + 5, use_month_numbers: true } %>
                   </div>
                 </div>
               </div>
@@ -48,13 +43,12 @@
               </div>
             </div>
           </div>
-      
-          <div class="flex justify-between mt-6 gap-3"> 
-            <%= link_to "キャンセル", user_foods_path, class: "flex-1 text-center py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 font-medium" %>
+          <div class="flex justify-between mt-6 gap-3">
+            <%= link_to "キャンセル", user_foods_path, class: "flex-1 text-center py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 font-medium", data: { action:"click->user-food-modal#closeModal" } %>
             <%= f.submit "更新", class: "flex-1 text-center py-2 rounded-md bg-orange-400 hover:bg-orange-500 text-white font-medium" %>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/user_foods/edit.html.erb
+++ b/app/views/user_foods/edit.html.erb
@@ -1,0 +1,60 @@
+<div class="fixed inset-0 bg-black/50 flex items-center justify-center z-5">
+  <div class="bg-white p-6 rounded shadow-md w-full md:max-w-xl max-w-md">
+    <div class="text-center">
+      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
+      冷蔵庫内の食材を修正
+      </h1>
+    </div>
+
+    <div class="rounded-2xl bg-white/70 backdrop-blur-sm mt-4 p-8 shadow-lg border border-orange-100">
+      <%= form_with(model: @user_food, data: { turbo: false }) do |f| %>
+      <%= render "shared/error_messages", object: f.object %>
+        <div class="flex items-center justify-center gap-4 mb-6">
+            <%= image_tag @user_food.food.food_image.variant(resize_to_limit: [80, 80]) %>
+            <div>
+              <h3 class="text-lg font-medium text-gray-900"><%= @user_food.food.name %></h3>
+              <p class="text-sm test-gray-500">
+                カテゴリー: <%= Category.find(@user_food.food.category_id).name %>
+              </p>
+            </div>
+          </div>
+
+          <div class="space-y-5 text-sm">
+            <div class="flex flex-wrap md:flex-nowrap gap-4 items-start">
+              <div class="w-20">
+                <%= f.label :quantity, class: "block font-medium text-gray-700 mb-1" %>
+                <%= f.number_field :quantity, min: 1, class: "w-full border border-gray-400 rounded px-4 py-2 text-center" %>
+              </div>
+              <div class="flex-1">
+                <%= f.label :deadline_date, class: "block font-medium text-gray-700 mb-1" %>
+                <div class="flex space-x-2">
+                  <div class="border border-gray-400 rounded px-2 py-2 text-sm">
+                    <%= select_year(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "1i", start_year: Date.today.year, end_year: Date.today.year + 5, class: "outline-none") %>
+                  </div>
+                  <div class="border border-gray-400 rounded px-2 py-2 text-sm">
+                    <%= select_month(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "2i", class: "outline-none") %>
+                  </div>
+                  <div class="border border-gray-400 rounded px-2 py-2 text-sm">
+                    <%= select_day(@user_food.deadline_date, prefix: "user_food[deadline_date]", field_name: "3i", class: "outline-none") %>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div>
+              <%= f.label :mini_memo, class: "block font-medium text-gray-700 mb-1" %>
+              <%= f.text_area :mini_memo, class: "w-full border border-gray-400 rounded px-4 py-2 text-sm resize-none" %>
+              <div class="text-right text-xs text-gray-500 mt-1">
+                <%= @user_food.mini_memo.length %>/50
+              </div>
+            </div>
+          </div>
+      
+          <div class="flex justify-between mt-6 gap-3"> 
+            <%= link_to "キャンセル", user_foods_path, class: "flex-1 text-center py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200 font-medium" %>
+            <%= f.submit "更新", class: "flex-1 text-center py-2 rounded-md bg-orange-400 hover:bg-orange-500 text-white font-medium" %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/user_foods/index.html.erb
+++ b/app/views/user_foods/index.html.erb
@@ -18,19 +18,19 @@
                       "bg-green-200"
                     end %>
       <% deadline_text = remaining_days %>
-      <div class="flex items-center rounded-xl shadow-md border py-4 px-8 mb-4 space-x-4 <%= bg_color %>">
+      <div class="flex items-center rounded-xl shadow-md border p-4 mb-4 space-x-4 <%= bg_color %>">
 
         <div class="flex-shrink-0 w-25 h-25 rounded-full flex items-center justify-center overflow-hidden">
           <%= image_tag user_food.food.food_image.variant(resize_to_limit: [80, 80]) %>
         </div>
 
-        <div class="flex flex-col flex-1 self-center text-sm space-y-1 ml-8">
-          <div class="flex items-center space-x-3">
+        <div class="flex flex-col flex-1 self-center text-sm space-y-1">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-start md:gap-4">
             <div class="font-bold text-lg"><%= user_food.food.name %></div>
             <% if deadline_text < 0 %>
               <div class="flex items-center space-x-1 font-bold text-lg text-red-500">
                 <span>お早めにどうぞ</span>
-                <%= heroicon "exclamation-triangle", options: { class: "w- h-5"}  %> 
+                <%= heroicon "exclamation-triangle", options: { class: "w-5 h-5" } %>
               </div>
             <% else %>
               <div class="font-bold text-lg text-red-500">あと<%= deadline_text %>日</div>
@@ -39,7 +39,7 @@
           <div class="font-semibold">期限: <%= user_food.deadline_date %></div>
           <div>数量: <%= user_food.quantity %><%= user_food.food.unit %></div>
           <% if user_food.mini_memo.present? %>
-            <div class="text-gray-600">メモ: <%= user_food.mini_memo %></div>
+            <div class="text-gray-700">メモ: <%= user_food.mini_memo %></div>
           <% end %>
         </div>
 

--- a/app/views/user_foods/index.html.erb
+++ b/app/views/user_foods/index.html.erb
@@ -1,58 +1,12 @@
 <main class="flex-1 px-6 py-8 md:px-8">
-  <div class="mx-auto max-w-md space-y-6">
+  <div class="mx-auto max-w-md md:max-w-xl space-y-6">
     <div class="text-center">
       <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
         冷蔵庫の中
       </h1>
     </div>
     <% @user_foods.each do |user_food| %>
-      <% remaining_days = (user_food.deadline_date - Date.today).to_i %>
-      <% bg_color = case remaining_days
-                    when ..0
-                      "bg-gray-200"
-                    when 1..2
-                      "bg-red-200"
-                    when 3..5
-                      "bg-yellow-200"
-                    else
-                      "bg-green-200"
-                    end %>
-      <% deadline_text = remaining_days %>
-      <div class="flex items-center rounded-xl shadow-md border p-4 mb-4 space-x-4 <%= bg_color %>">
-
-        <div class="flex-shrink-0 w-25 h-25 rounded-full flex items-center justify-center overflow-hidden">
-          <%= image_tag user_food.food.food_image.variant(resize_to_limit: [80, 80]) %>
-        </div>
-
-        <div class="flex flex-col flex-1 self-center text-sm space-y-1">
-          <div class="flex flex-col md:flex-row md:items-center md:justify-start md:gap-4">
-            <div class="font-bold text-lg"><%= user_food.food.name %></div>
-            <% if deadline_text < 0 %>
-              <div class="flex items-center space-x-1 font-bold text-lg text-red-500">
-                <span>お早めにどうぞ</span>
-                <%= heroicon "exclamation-triangle", options: { class: "w-5 h-5" } %>
-              </div>
-            <% else %>
-              <div class="font-bold text-lg text-red-500">あと<%= deadline_text %>日</div>
-            <% end %>
-          </div>
-          <div class="font-semibold">期限: <%= user_food.deadline_date %></div>
-          <div>数量: <%= user_food.quantity %><%= user_food.food.unit %></div>
-          <% if user_food.mini_memo.present? %>
-            <div class="text-gray-700">メモ: <%= user_food.mini_memo %></div>
-          <% end %>
-        </div>
-
-        <div class="flex flex-col items-center justify-center space-y-4">
-          <%= link_to edit_user_food_path(id: user_food.id), class: "text-gray-500 hover:text-blue-600" do %>
-            <%= heroicon "pencil", options: { class: "w-6 h-6"} %>
-          <% end %>
-          <%= link_to user_food_path(id: user_food.id), data: { turbo_method: :delete, turbo_confirm: "削除してよろしいですか" }, class: "text-gray-500 hover:text-red-600" do %>
-            <%= heroicon "trash", options: { class: "w-6 h-6"} %>
-          <% end %>
-        </div>
-
-      </div>
+      <%= render partial: "user_food", locals: { user_food: user_food } %>
     <% end %>
   </div>
 </main>

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -52,7 +52,7 @@
                           end %>
                   <% end %>
                   <%= f.date_select :deadline_date, 
-                      { default: (Time.now + food.default_deadline.days) }, 
+                      { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, , use_month_numbers: true }, 
                       { class: "border rounded px-1 py-0.5 text-sm", date_separator: '', order: [:year, :month, :day] } %>
                 </div>
                 <p class="text-sm text-gray-600">

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -52,7 +52,7 @@
                           end %>
                   <% end %>
                   <%= f.date_select :deadline_date, 
-                      { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, , use_month_numbers: true }, 
+                      { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, use_month_numbers: true }, 
                       { class: "border rounded px-1 py-0.5 text-sm", date_separator: '', order: [:year, :month, :day] } %>
                 </div>
                 <p class="text-sm text-gray-600">

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -1,5 +1,5 @@
 <main class="flex-1 px-6 py-8 md:px-8">
-  <div class="mx-auto max-w-md space-y-6">
+  <div class="mx-auto max-w-md md:max-w-6xl space-y-6">
     <div class="text-center">
       <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
         登録する食材

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     resource :password, only: %i[edit update]
   end
   resources :foods, only: %i[index new create edit update destroy]
-  resources :user_foods
+  resources :user_foods, only: %i[index new create edit update destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要
冷蔵庫内の食材を編集

## 内容
- 編集画面はモーダル化
- `user_food`の部分テンプレート作成
- `user_foods#index`で`user_food`部分テンプレートを`render`で表示
- フラッシュメッセージの横幅修正
- `user_foods#new`の`date_select`のオプション追加(`start_year`, `end_year`, `use_month_numbers`)
- `user_foods#new`, `user_foods#index`をスマホとPCで横幅を変更するCSS修正

#### ISSUE番号
closed #22 