### PR TITLE
1つのフォームで複数の食材を登録できる

### DIFF
--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -8,12 +8,14 @@ class UserFoodsController < ApplicationController
   def new
     @categories = Category.order(id: :asc)
     @foods = Food.where(category_id: params[:category_id]).order(name: :asc)
-    @user_food = current_user.user_foods.new
+    @form = Form::UserFoodCollection.new(current_user, @foods)
   end
 
   def create
-    @user_food = current_user.user_foods.build(user_foods_params)
-    if @user_food.save
+    @foods = Food.where(category_id: params[:category_id]).order(name: :asc)
+    @form = Form::UserFoodCollection.new(current_user, @foods, user_foods_params)
+    if @form.save
+      @user_food = current_user.user_foods.order(created_at: :desc).first
       flash.now[:notice] = "冷蔵庫に食材を登録しました"
       render turbo_stream: [
         turbo_stream.replace("user_food", partial: "user_foods/user_food", locals: { user_food: @user_food }),
@@ -52,7 +54,7 @@ class UserFoodsController < ApplicationController
   private
 
   def user_foods_params
-    params.require(:user_food).permit(:food_id, :quantity, :deadline_date, :mini_memo)
+    params.require(:form_user_food_collection).permit(user_foods_attributes:  [:food_id, :quantity, :deadline_date, :mini_memo])
   end
 
   def find_registered_user_food

--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -54,7 +54,7 @@ class UserFoodsController < ApplicationController
   private
 
   def user_foods_params
-    params.require(:form_user_food_collection).permit(user_foods_attributes:  [:food_id, :quantity, :deadline_date, :mini_memo])
+    params.require(:form_user_food_collection).permit(user_foods_attributes:  [ :food_id, :quantity, :deadline_date, :mini_memo ])
   end
 
   def find_registered_user_food

--- a/app/javascript/controllers/details_modal_controller.js
+++ b/app/javascript/controllers/details_modal_controller.js
@@ -1,0 +1,44 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="details-modal"
+export default class extends Controller {
+  static targets = ["detailModal", "item"]
+
+  connect() {
+    this.detailModalTarget.classList.add("hidden");
+  }
+
+  populate(event){
+    const selections = event.detail?.selections;
+    // selectionsが空の場合はreturn
+    if(!Array.isArray(selections) || selections.length === 0) {
+      return this.detailModalTarget.classList.add("hidden");
+    }
+    // selectionsのindexを文字列としてmap
+    const selected = new Set(selections.map(s => String(s.index)));
+    // selectionsのindexと食材のindexが一致した場合は表示、しない場合は非表示
+    this.itemTargets.forEach(item => {
+      const idx = item.dataset.index;
+      const fields = item.querySelectorAll('input, select, textarea');
+      if(selected.has(idx)) {
+        item.classList.remove("hidden");
+        fields.forEach(f => f.disabled = false);
+      } else {
+        item.classList.add("hidden");
+        fields.forEach(f => f.disabled = true);
+      }
+    })
+    // モーダルを開く
+    this.detailModalTarget.classList.remove("hidden");
+  }
+
+  close(event){
+    if(event.detail.success){
+      this.detailModalTarget.classList.add("hidden");
+    }
+  }
+
+  closeModal(){
+    this.detailModalTarget.classList.add("hidden");
+  }
+}

--- a/app/javascript/controllers/foods_selection_controller.js
+++ b/app/javascript/controllers/foods_selection_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="foods-selection"
+export default class extends Controller {
+  static targets = ["quantity", "nextButton"]
+
+  connect() {
+    this.check();
+  }
+
+  open(){
+    // 空の配列
+    let selections = [];
+    // 数量を取り出して、0より大きい値のとき、インデックスと数量を空の配列に追加
+    this.quantityTargets.forEach((element) => {
+      const idx = element.dataset.index;
+      const n = Number(element.value || "0");
+      if (n > 0) {
+        selections.push({ index: idx, quantity: n});
+      }
+    })
+    if (selections.length !== 0) {
+      // 数量の値をdetails-modalに引き渡す
+      const event = new CustomEvent("foods:selected", { detail: { selections }, bubbles: true })
+      this.element.dispatchEvent(event);
+    }
+  }
+
+  check(){
+    // 空の配列
+    let presentQuantities = [];
+    // 数量を1つずつ取り出して、文字列を数値化し、空の配列に追加していく
+    this.quantityTargets.forEach((element) => {
+      presentQuantities.push(Number(element.value || "0"));
+    });
+    // presentQuantitiesの配列の値が0よりも大きい値があればtrue
+    const any = presentQuantities.some((element) => element > 0);
+    // anyがtrueの場合に限り、ボタンを押せる(disabled = false)
+    this.nextButtonTarget.disabled = !any;
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,8 +7,14 @@ import { application } from "./application"
 import AccountModalController from "./account_modal_controller"
 application.register("account-modal", AccountModalController)
 
+import DetailsModalController from "./details_modal_controller"
+application.register("details-modal", DetailsModalController)
+
 import FoodsModalController from "./foods_modal_controller"
 application.register("foods-modal", FoodsModalController)
+
+import FoodsSelectionController from "./foods_selection_controller"
+application.register("foods-selection", FoodsSelectionController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/models/form/user_food_collection.rb
+++ b/app/models/form/user_food_collection.rb
@@ -1,7 +1,7 @@
 class Form::UserFoodCollection < Form::Base
   attr_accessor :user_foods, :user, :foods
 
-  def initialize(user, foods, attributes={})
+  def initialize(user, foods, attributes = {})
     @user = user
     @foods = foods
     super attributes
@@ -35,12 +35,12 @@ class Form::UserFoodCollection < Form::Base
     end
     UserFood.transaction do
       # すでに登録済みのuser_foodsのfood_id, deadline_dateを取得
-      rows = @user.user_foods.index_by{ |uf| [uf.food_id, uf.deadline_date] }
+      rows = @user.user_foods.index_by { |uf| [ uf.food_id, uf.deadline_date ] }
       registered_user_foods.each do |ruf|
         # フォームから取得した食材が登録済みの食材と期限が一致している場合は既存のデータを更新
         # 新規または期限が異なる場合は新規登録
-        if rows.key?([ruf.food_id, ruf.deadline_date])
-          existing = rows[[ruf.food_id, ruf.deadline_date]]
+        if rows.key?([ ruf.food_id, ruf.deadline_date ])
+          existing = rows[[ ruf.food_id, ruf.deadline_date ]]
           sum = existing.quantity + ruf.quantity.to_i
           existing.update!(quantity: sum)
         else

--- a/app/models/form/user_food_collection.rb
+++ b/app/models/form/user_food_collection.rb
@@ -1,0 +1,56 @@
+class Form::UserFoodCollection < Form::Base
+  attr_accessor :user_foods, :user, :foods
+
+  def initialize(user, foods, attributes={})
+    @user = user
+    @foods = foods
+    super attributes
+    self.user_foods = default_user_foods if self.user_foods.blank?
+  end
+
+  def default_user_foods
+    @foods.map do |f|
+      UserFood.new(user_id: @user.id, food_id: f.id)
+    end
+  end
+
+  def user_foods_attributes=(attributes)
+    self.user_foods = attributes.map do |_, v|
+      UserFood.new(v.merge(user_id: @user.id))
+    end
+  end
+
+  def select_user_foods
+    # quantity>0の食材を取得
+    self.user_foods.select { |uf| (uf.quantity || 0).to_i > 0 }
+  end
+
+
+  def save
+    registered_user_foods = select_user_foods
+    # 空だった場合は1つ以上の食材の数量を選択するよう にエラー
+    if registered_user_foods.blank?
+      errors.add(:base, "登録する食材の数量を入力してください")
+      return false
+    end
+    UserFood.transaction do
+      # すでに登録済みのuser_foodsのfood_id, deadline_dateを取得
+      rows = @user.user_foods.index_by{ |uf| [uf.food_id, uf.deadline_date] }
+      registered_user_foods.each do |ruf|
+        # フォームから取得した食材が登録済みの食材と期限が一致している場合は既存のデータを更新
+        # 新規または期限が異なる場合は新規登録
+        if rows.key?([ruf.food_id, ruf.deadline_date])
+          existing = rows[[ruf.food_id, ruf.deadline_date]]
+          sum = existing.quantity + ruf.quantity.to_i
+          existing.update!(quantity: sum)
+        else
+          ruf.save!
+        end
+      end
+    end
+    true
+  rescue => e
+    Rails.logger.warn(e.message)
+    false
+  end
+end

--- a/app/views/categories/_category_nav.html.erb
+++ b/app/views/categories/_category_nav.html.erb
@@ -1,10 +1,15 @@
-<div class="overflow-x-auto whitespace-nowrap px-4">
-  <ul class="inline-flex space-x-4">
-    <% categories.each do |category| %>
-      <li>
-        <%= link_to category.name, new_user_food_path(category_id: category.id), data: { turbo_frame: 'foods_list' }, class: "px-4 py-1 rounded-full border text-sm font-medium transition " +
-           (params[:category_id].to_i == category.id ? "bg-pink-200 text-pink-800 font-bold" : "bg-white border-gray-300 hover:bg-pink-100") %>
-      </li>
-    <% end %>
-  </ul>
+<div class="px-4 py-4">
+  <div class="mx-auto max-w-5xl">
+    <div class="overflow-x-auto overflow-y-hidden">
+      <ul class="flex gap-2 w-fit mx-auto px-2 whitespace-nowrap">
+        <% categories.each do |category| %>
+          <li class="flex-shrink-0">
+            <%= link_to category.name, new_user_food_path(category_id: category.id), data: { turbo_frame: 'foods_list' }, 
+            class: "inline-flex items-center px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 " + 
+            (params[:category_id].to_i == category.id ? "bg-orange-200 text-orange-700" : "bg-gray-100 text-gray-700 hover:bg-gray-200") %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/app/views/user_foods/_details.html.erb
+++ b/app/views/user_foods/_details.html.erb
@@ -1,0 +1,89 @@
+<%= turbo_frame_tag "details_modal" do %>
+  <!-- モーダル全体 -->
+  <div data-controller="details-modal" data-details-modal-target="detailModal" data-action="foods:selected@document->details-modal#populate turbo:submit-end@document->details-modal#close" class="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6" role="dialog" aria-modal="true">
+    <!-- 背景 -->
+    <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" data-action="click->details-modal#closeModal"></div>
+    <!-- 本体カード -->
+    <div class="relative w-full max-w-4xl bg-white rounded-2xl shadow-2xl overflow-hidden">
+      <!-- 閉じる -->
+      <button type="button"
+              class="absolute right-3 top-3 inline-flex items-center justify-center rounded-full size-8 hover:bg-gray-100"
+              data-action="click->details-modal#closeModal" aria-label="閉じる"><%= heroicon "x-circle",  variant: :outline, options: { class: "w-5 h-5 text-gray-700"} %></button>
+
+      <div class="p-4 sm:p-6 max-h-[calc(100vh-4rem)] overflow-y-auto">
+        <h2 class="text-lg font-semibold mb-4">食材の詳細</h2>
+
+        <div class="space-y-4">
+          <% foods.each_with_index do |food, i| %>
+            <% fa = form.object.user_foods[i] %>
+            <%= form.fields_for(:user_foods, fa, child_index: i) do |f| %>
+              <!-- 1食材＝カードで囲う -->
+              <section data-details-modal-target="item" data-index="<%= i %>" class="rounded-xl border border-gray-200 bg-white/80 shadow-sm hover:shadow-md transition-shadow">
+                <div class="p-4 sm:p-5 flex flex-col sm:flex-row items-start gap-4">
+                  <!-- 左：食材名＋画像 -->
+                  <div class="w-full sm:w-44 shrink-0 flex flex-col items-center gap-2 text-center">
+                    <% if food.user_id == current_user.id %>
+                      <div class="space-x-1">
+                        <%= link_to edit_food_path(id: food.id), data: { turbo_frame: 'foods_modal' }, class: "inline-flex items-center gap-1 text-gray-800 hover:text-gray-900 hover:underline" do %>
+                          <span class="font-medium"><%= food.name %></span>
+                          <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
+                        <% end %>
+                      </div>
+                      <div class="bg-white size-24 rounded-full flex items-center justify-center border-2 border-gray-300">
+                        <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
+                      </div>
+                    <% else %>
+                      <div class="font-medium text-gray-900"><%= food.name %></div>
+                      <div class="bg-white size-24 rounded-full flex items-center justify-center border-2 border-gray-300">
+                        <% if food.food_image.attached? %>
+                          <%= image_tag food.food_image.variant(resize_to_limit: [80, 80]), class: "block" %>
+                        <% else %>
+                          <span class="text-xs text-gray-400"><%= t('.no_image') %></span>
+                        <% end %>
+                      </div>
+                    <% end %>
+                  </div>
+
+                  <!-- 右：期限＋メモ -->
+                  <div class="w-full sm:flex-1">
+                    <div class="mb-4 text-left">
+                      <%= f.label :deadline_date, class: "block mb-1 font-medium" %>
+                      <div class="flex flex-wrap items-center gap-2">
+                        <%# default_deadline が nil の場合、肉(3)/魚(4)=2日、その他=7日 %>
+                        <% default_deadline = 
+                          food.default_deadline.presence ||
+                          ([3,4].include?(food.category_id) ? 2 : 7) %>
+                        <%= f.date_select :deadline_date,
+                          { default: (Time.current + default_deadline.days),
+                            start_year: Date.today.year, end_year: Date.today.year + 5, date_separator: '',
+                            use_month_numbers: true, order: [:year, :month, :day] },
+                          { class: "border rounded px-2 py-1 text-sm" } %>
+                      </div>
+                      <p class="mt-2 text-sm text-gray-600 leading-relaxed">
+                        この食材の冷蔵保存目安は
+                        <span class="text-red-500 font-semibold">
+                          <%= default_deadline %>日
+                        </span>です。<br>
+                        賞味期限や消費期限の表示がある場合はそちらに従ってください。
+                      </p>
+                    </div>
+
+                    <div class="mb-1 text-left">
+                      <%= f.label :mini_memo, class: "block mb-1 font-medium" %>
+                      <%= f.text_area :mini_memo, class: "w-full border rounded px-3 py-2", placeholder: "冷凍済み, 小分け済み" %>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            <% end %>
+          <% end %>
+        </div>
+
+        <div class="mt-6 flex justify-end gap-3">
+          <button type="button" class="px-4 py-2 rounded-xl border hover:bg-gray-50" data-action="click->details-modal#closeModal">閉じる</button>
+          <%= form.submit "保存する", class: "px-4 py-2 rounded-xl bg-orange-500 text-white font-semibold hover:bg-orange-600 shadow" %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/user_foods/_details.html.erb
+++ b/app/views/user_foods/_details.html.erb
@@ -8,10 +8,11 @@
       <!-- 閉じる -->
       <button type="button"
               class="absolute right-3 top-3 inline-flex items-center justify-center rounded-full size-8 hover:bg-gray-100"
-              data-action="click->details-modal#closeModal" aria-label="閉じる"><%= heroicon "x-circle",  variant: :outline, options: { class: "w-5 h-5 text-gray-700"} %></button>
+              data-action="click->details-modal#closeModal" aria-label="閉じる"><%= heroicon "x-circle",  variant: :outline, options: { class: "w-10 h-10 text-gray-700"} %></button>
 
       <div class="p-4 sm:p-6 max-h-[calc(100vh-4rem)] overflow-y-auto">
-        <h2 class="text-lg font-semibold mb-4">食材の詳細</h2>
+        <h2 class="text-lg font-semibold">step2: 期限・メモを入力してください</h2>
+        <p class="text-sm text-gray-600 mt-1 mb-2">メモは必須ではありません。保存状態や使い方などを自由に記録できます。</p>
 
         <div class="space-y-4">
           <% foods.each_with_index do |food, i| %>
@@ -34,9 +35,9 @@
                       </div>
                     <% else %>
                       <div class="font-medium text-gray-900"><%= food.name %></div>
-                      <div class="bg-white size-24 rounded-full flex items-center justify-center border-2 border-gray-300">
+                      <div class="bg-white size-30 rounded-full flex items-center justify-center border-1 border-gray-300">
                         <% if food.food_image.attached? %>
-                          <%= image_tag food.food_image.variant(resize_to_limit: [80, 80]), class: "block" %>
+                          <%= image_tag food.food_image.variant(resize_to_limit: [100, 100]), class: "block" %>
                         <% else %>
                           <span class="text-xs text-gray-400"><%= t('.no_image') %></span>
                         <% end %>
@@ -64,13 +65,13 @@
                         <span class="text-red-500 font-semibold">
                           <%= default_deadline %>日
                         </span>です。<br>
-                        賞味期限や消費期限の表示がある場合はそちらに従ってください。
+                        賞味期限や消費期限の表示がある場合は、そちらに従ってください。
                       </p>
                     </div>
 
                     <div class="mb-1 text-left">
                       <%= f.label :mini_memo, class: "block mb-1 font-medium" %>
-                      <%= f.text_area :mini_memo, class: "w-full border rounded px-3 py-2", placeholder: "冷凍済み, 小分け済み" %>
+                      <%= f.text_area :mini_memo, class: "w-full border rounded px-3 py-2", placeholder: "例: 冷凍済み, 小分け済み" %>
                     </div>
                   </div>
                 </div>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -1,30 +1,30 @@
 <%= turbo_frame_tag "foods", id: "foods" do %>
   <div data-controller="foods-selection">
-    <%= form_with model: @form, url: user_foods_path, html: { class: "flex flex-wrap gap-6" } do |form| %>
+    <%= form_with model: @form, url: user_foods_path, html: { class: "mx-auto max-w-7xl grid gap-6 grid-cols-2 md:grid-cols-3 xl:grid-cols-5" } do |form| %>
     <%= render "shared/error_messages", object: form.object %>
 
       <% foods.each_with_index do |food, i| %>
-        <div class="basis-44 shrink-0 flex flex-col items-center gap-2">
+        <div class="flex flex-col items-stretch gap-3 rounded-2xl bg-white shadow-sm ring-1 ring-gray-100 p-4">
           <%# ユーザーが食材リストに追加した食材の場合、食材の編集ができる %>
           <%# ユーザーが追加した食材リストの画像は指定 %>
           <% if food.user_id == current_user.id %>
-            <div class="text-center space-x-2">
+            <div class="text-left space-x-2 font-semibold text-gray-800 px-1">
               <%= link_to edit_food_path(id: food.id), data: { turbo_frame: 'foods_modal' }, class: "inline-flex items-center space-x-1" do %>
                 <%= food.name %>
                 <%= heroicon "pencil", options: { class: "w-4 h-4 text-gray-700"} %>
               <% end %>
             </div>
-            <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
-              <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
+            <div class="bg-gray-100 h-48 w-full rounded-xl flex items-center justify-center ring-1 ring-gray-200">
+              <p>画像なし</p>
             </div>
           <% else %>
             <%# デフォルトの食材を表示 %>
-            <div class="text-center">
+            <div class="text-left font-semibold text-gray-800 px-1">
               <%= food.name %>
             </div>
-            <div class="bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center border-2 border-gray-300">
+            <div class="bg-gray-100 h-48 w-full rounded-xl flex items-center justify-center ring-1 ring-gray-200">
               <% if food.food_image.attached? %>
-                <%= image_tag food.food_image.variant(resize_to_limit: [80, 80]) %>
+                <%= image_tag food.food_image.variant(resize_to_limit: [150, 150]) %>
               <% else %>
                 <span class="text-xs text-gray-400"><%= t('.no_image') %></span>
               <% end %>
@@ -35,22 +35,24 @@
           <% fa = form.object.user_foods[i] %>
           <%= form.fields_for(:user_foods, fa, child_index: i) do |f| %>
             <%= f.hidden_field :food_id, value: food.id %>
-            <div class="flex items-center justify-center">
-              <%= f.label :quantity, class: "w-10 text-left" %>
-              <%= f.number_field :quantity, min: 0, step: 1, data: { foods_selection_target: "quantity", index: i, action: "input->foods-selection#check" }, class: "w-20 border rounded px-2 py-0.5" %>
-              <%= food.unit %>
+            <div class="mt-2 flex items-center gap-3">
+              <%= f.label :quantity, class: "mr-2 text-sm text-gray-600" %>
+              <%= f.number_field :quantity, min: 0, step: 1, data: { foods_selection_target: "quantity", index: i, action: "input->foods-selection#check" }, class: "w-16 text-center border border-gray-300 rounded-lg px-3 py-2 shadow-inner" %>
+              <span class="text-sm text-gray-600"><%= food.unit %></span>
             </div>
           <% end %>
         </div>
       <% end %>
-
-      <button
-        data-action="click->foods-selection#open"
-        data-foods-selection-target="nextButton"
-        type="button"
-        class="px-8 py-3 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"  disabled>
-        次へ
-      </button>
+      
+      <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-100 p-4 pb-safe">
+        <button
+          data-action="click->foods-selection#open"
+          data-foods-selection-target="nextButton"
+          type="button"
+          class="w-full py-4 px-6 bg-orange-500 text-white font-medium rounded-2xl shadow-lg transition-all duration-200 disabled:bg-gray-300 disabled:cursor-not-allowed enabled:hover:bg-orange-600 enabled:active:scale-98 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2"  disabled>
+          次へ
+        </button>
+      </div>
 
       <%= render 'details', form: form, foods: @foods, class: "hidden" %>
     <% end %>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "foods", id: "foods" do %>
-  <div class="flex flex-wrap gap-4">
-    <%= form_with model: @form, url: user_foods_path do |form| %>
-      <% foods.each_with_index do |food, i| %>
-      <%= render "shared/error_messages", object: form.object %>
-        <div class="flex flex-col items-center space-y-2">
+  <div data-controller="foods-selection">
+    <%= form_with model: @form, url: user_foods_path, html: { class: "flex flex-wrap gap-6" } do |form| %>
+    <%= render "shared/error_messages", object: form.object %>
 
+      <% foods.each_with_index do |food, i| %>
+        <div class="basis-44 shrink-0 flex flex-col items-center gap-2">
           <%# ユーザーが食材リストに追加した食材の場合、食材の編集ができる %>
           <%# ユーザーが追加した食材リストの画像は指定 %>
           <% if food.user_id == current_user.id %>
@@ -30,48 +30,29 @@
               <% end %>
             </div>
           <% end %>
-          <%# 冷蔵庫に登録するform %>
+
+          <%# 冷蔵庫に登録する食材の数量を入力 %>
           <% fa = form.object.user_foods[i] %>
-          <%= form.fields_for :user_foods, fa do |f| %>
+          <%= form.fields_for(:user_foods, fa, child_index: i) do |f| %>
             <%= f.hidden_field :food_id, value: food.id %>
             <div class="flex items-center justify-center">
               <%= f.label :quantity, class: "w-10 text-left" %>
-              <%= f.number_field :quantity, min: 0, class: "w-20 border rounded px-2 py-0.5" %>
+              <%= f.number_field :quantity, min: 0, step: 1, data: { foods_selection_target: "quantity", index: i, action: "input->foods-selection#check" }, class: "w-20 border rounded px-2 py-0.5" %>
               <%= food.unit %>
-            </div>
-            <div class="mb-3 text-left">
-              <%= f.label :deadline_date, class: "block mb-1" %>
-              <div class="flex space-x-2 mb-1">
-                <%# default_deadlineがnilの場合は、肉・魚介は2
-                日、それ以外は7日で計算 %>
-                <% unless food.default_deadline.present? %>
-                <% food.default_deadline = 
-                  case food.category_id
-                  when 3, 4
-                    2
-                  else
-                    7
-                  end %>
-                <% end %>
-                <%= f.date_select :deadline_date, 
-                  { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, use_month_numbers: true }, 
-                  { class: "border rounded px-1 py-0.5 text-sm", date_separator: '', order: [:year, :month, :day] } %>
-              </div>
-              <p class="text-sm text-gray-600">
-                この食材の冷蔵保存目安は
-                <span class="text-red-500 font-semibold"><%= food.default_deadline %>日</span>です。<br>
-                賞味期限や消費期限が記載されて<br>
-                いれば、そちらに従ってください。
-              </p>
-            </div>
-            <div class="mb-4 text-left">
-              <%= f.label :mini_memo, class: "block mb-1"  %>
-              <%= f.text_field :mini_memo, class: "flex-1 border rounded  px-2 py-0.5", placeholder: "冷凍済み, 小分け済み" %>
             </div>
           <% end %>
         </div>
       <% end %>
-      <%= form.submit "登録", class: "block text-center px-4 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+
+      <button
+        data-action="click->foods-selection#open"
+        data-foods-selection-target="nextButton"
+        type="button"
+        class="px-8 py-3 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200"  disabled>
+        次へ
+      </button>
+
+      <%= render 'details', form: form, foods: @foods, class: "hidden" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -1,9 +1,12 @@
 <%= turbo_frame_tag "foods", id: "foods" do %>
   <div class="flex flex-wrap gap-4">
-    <% foods.each do |food| %>
-      <%= form_with model: user_food do |f| %>
-      <%= render "shared/error_messages", object: f.object %>
+    <%= form_with model: @form, url: user_foods_path do |form| %>
+      <% foods.each_with_index do |food, i| %>
+      <%= render "shared/error_messages", object: form.object %>
         <div class="flex flex-col items-center space-y-2">
+
+          <%# ユーザーが食材リストに追加した食材の場合、食材の編集ができる %>
+          <%# ユーザーが追加した食材リストの画像は指定 %>
           <% if food.user_id == current_user.id %>
             <div class="text-center space-x-2">
               <%= link_to edit_food_path(id: food.id), data: { turbo_frame: 'foods_modal' }, class: "inline-flex items-center space-x-1" do %>
@@ -15,6 +18,7 @@
               <i class="material-symbols-rounded !text-4xl" style="font-variation-settings: 'wght' 100;">washoku</i>
             </div>
           <% else %>
+            <%# デフォルトの食材を表示 %>
             <div class="text-center">
               <%= food.name %>
             </div>
@@ -26,42 +30,48 @@
               <% end %>
             </div>
           <% end %>
-          <%= f.hidden_field :food_id, value: food.id %>
-          <div class="flex items-center justify-center">
-            <%= f.label :quantity, class: "w-10 text-left" %>
-            <%= f.number_field :quantity, class: "w-20 border rounded px-2 py-0.5" %>
-            <%= food.unit %>
-          </div>
-          <div class="mb-3 text-left">
-            <%= f.label :deadline_date, class: "block mb-1" %>
-            <div class="flex space-x-2 mb-1">
-              <% unless food.default_deadline.present? %>
-              <% food.default_deadline = 
-                case food.category_id
-                when 3, 4
-                  2
-                else
-                  7
-                end %>
-              <% end %>
-              <%= f.date_select :deadline_date, 
-                { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, use_month_numbers: true }, 
-                { class: "border rounded px-1 py-0.5 text-sm", date_separator: '', order: [:year, :month, :day] } %>
+          <%# 冷蔵庫に登録するform %>
+          <% fa = form.object.user_foods[i] %>
+          <%= form.fields_for :user_foods, fa do |f| %>
+            <%= f.hidden_field :food_id, value: food.id %>
+            <div class="flex items-center justify-center">
+              <%= f.label :quantity, class: "w-10 text-left" %>
+              <%= f.number_field :quantity, min: 0, class: "w-20 border rounded px-2 py-0.5" %>
+              <%= food.unit %>
             </div>
-            <p class="text-sm text-gray-600">
-              この食材の冷蔵保存目安は
-              <span class="text-red-500 font-semibold"><%= food.default_deadline %>日</span>です。<br>
-              賞味期限や消費期限が記載されて<br>
-              いれば、そちらに従ってください。
-            </p>
-          </div>
-          <div class="mb-4 text-left">
-            <%= f.label :mini_memo, class: "block mb-1"  %>
-            <%= f.text_field :mini_memo, class: "flex-1 border rounded  px-2 py-0.5", placeholder: "冷凍済み, 小分け済み" %>
-          </div>
-          <%= f.submit "登録", class: "block text-center px-4 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+            <div class="mb-3 text-left">
+              <%= f.label :deadline_date, class: "block mb-1" %>
+              <div class="flex space-x-2 mb-1">
+                <%# default_deadlineがnilの場合は、肉・魚介は2
+                日、それ以外は7日で計算 %>
+                <% unless food.default_deadline.present? %>
+                <% food.default_deadline = 
+                  case food.category_id
+                  when 3, 4
+                    2
+                  else
+                    7
+                  end %>
+                <% end %>
+                <%= f.date_select :deadline_date, 
+                  { default: (Time.now + food.default_deadline.days), start_year: Date.today.year, end_year: Date.today.year + 5, use_month_numbers: true }, 
+                  { class: "border rounded px-1 py-0.5 text-sm", date_separator: '', order: [:year, :month, :day] } %>
+              </div>
+              <p class="text-sm text-gray-600">
+                この食材の冷蔵保存目安は
+                <span class="text-red-500 font-semibold"><%= food.default_deadline %>日</span>です。<br>
+                賞味期限や消費期限が記載されて<br>
+                いれば、そちらに従ってください。
+              </p>
+            </div>
+            <div class="mb-4 text-left">
+              <%= f.label :mini_memo, class: "block mb-1"  %>
+              <%= f.text_field :mini_memo, class: "flex-1 border rounded  px-2 py-0.5", placeholder: "冷凍済み, 小分け済み" %>
+            </div>
+          <% end %>
         </div>
       <% end %>
+      <%= form.submit "登録", class: "block text-center px-4 bg-orange-200 hover:bg-orange-300 text-orange-600 font-semibold py-2 text-lg rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -1,16 +1,36 @@
 <main class="flex-1 px-6 py-8 md:px-8">
-  <div class="mx-auto max-w-md md:max-w-6xl space-y-6">
+  <div class="mx-auto max-w-xl md:max-w-7xl space-y-6">
     <div class="text-center">
-      <h1 class="text-3xl font-bold bg-gradient-to-r from-orange-500 to-pink-500 bg-clip-text text-transparent md:text-4xl">
-        登録する食材
+      <h1 class="text-3xl md:text-4xl font-semibold tracking-tight text-gray-600">
+        冷蔵庫に追加する食材を選択
       </h1>
     </div>
-    <%= render 'categories/category_nav', categories: @categories %>
-    <%= render "new_form", foods: @foods, user_food: @user_food %>
-    <div class="flex flex-wrap gap-4">
-      <%= link_to new_food_path(category_id: params[:category_id]), data: { turbo_frame: 'foods_modal' }, class: "bg-white w-[100px] h-[100px] rounded-full flex items-center justify-center mt-6 border-2 border-gray-300" do %>
-        <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>          
-      <% end %>
+    <div class="min-h-screen flex justify-center items-start">
+      <div class="bg-white shadow-sm border border-gray-100 rounded-2xl w-full max-w-6xl">
+        <div class="py-6 text-center">
+          <h1 class="text-xl font-medium text-gray-900 leading-relaxed">
+            step1: 登録したい食材の数量を入力してください
+          </h1>
+          <p class="text-sm text-gray-600 mt-2">
+            登録はカテゴリー単位です。同じカテゴリー内なら複数の食材を一度に登録できます。
+          </p>
+        </div>
+
+        <div class="border-b border-gray-100">
+          <%= render 'categories/category_nav', categories: @categories %>
+        </div>
+
+        <div class="mt-4 mx-4">
+          <%= render "new_form", foods: @foods, user_food: @user_food %>
+        </div>
+
+        <div class="flex justify-center my-4">
+          <%= link_to new_food_path(category_id: params[:category_id]), data: { turbo_frame: 'foods_modal' }, class: "flex items-center gap-2 px-6 py-3 bg-white rounded-xl border-1 border-gray-200 shadow-sm hover:shadow-md transition text-gray-700 font-medium" do %>
+            <%= heroicon "plus", options: { class: "w-10 h-10 text-gray-800" } %>
+            食材追加    
+          <% end %>
+        </div>
+      </div>
     </div>
   </div>
 </main>


### PR DESCRIPTION
## 概要
- 1つのフォームで複数の食材を登録できる
- 食材の登録は数量->期限・メモ->登録の順で入力する
- `user_foods#new`のUI修正

## 内容
- 1つのフォームで複数の食材を登録できる
  - `form/user_food_collection`作成
  - 数量が0よりも大きい値のデータだけ取得
  - すでに登録済みの食材名と期限が一緒の場合は数量を更新
  - 新規または期限が異なる場合は新規登録
- 食材の登録は数量->期限・メモ->登録の順で入力する
  - `Stimulus`で対応(`foods_selection`, `details_modal`)
  - 数量の入力がない場合に`次へ`のボタンが押せない(`foods_selection`)
  - 数量が0よりも大きい値のデータのみ`details-modal`に引き渡し、表示する(`foods_selection`, `details_modal`)
  - 期限・メモの入力はモーダル化(`details_modal`)

#### ISSUE番号
closed #41
closed #90