### PR TITLE
MVPリリースのレビューフィードバックによる修正

### DIFF
--- a/app/views/food_actions/_form.html.erb
+++ b/app/views/food_actions/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: form, url: url, method: :post do |form| %>
   <%= render "shared/error_messages", object: form.object %>
-  <div class="bg-white rounded-2xl shadow-md px-4 py-2 max-w-3xl mx-2 mb-2">
+  <div class="bg-white rounded-2xl shadow-md px-4 py-2 max-w-3xl mx-2 mb-2 ">
     <div class="py-2 text-center">
       <h1 class="text-xl font-medium text-gray-900 leading-relaxed">
         食材を選択し、数量を入力してください
@@ -77,7 +77,7 @@
         </div>
       <% end %>
     <% end %>
-    <div class="fixed bottom-0 left-20 right-20 md:left-50 md:right-50 xl:left-100 xl:right-100 p-4 pb-safe">
+    <div class="sticky bottom-[calc(64px+env(safe-area-inset-bottom))] z-40 mx-auto max-w-3xl px-4 pb-safe">
       <%= form.submit t('.registration'), class: "w-full px-4 py-4 rounded-xl bg-orange-500 text-white font-semibold hover:bg-orange-600 shadow" %>
     </div>
   </div>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -45,7 +45,7 @@
         </div>
       <% end %>
       
-      <div class="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-100 p-4 pb-safe">
+      <div class="col-span-full sticky bottom-[calc(64px+env(safe-area-inset-bottom))] z-40">
         <button
           data-action="click->foods-selection#open"
           data-foods-selection-target="nextButton"


### PR DESCRIPTION
## 概要
ボタンがフッターで隠れてしまい登録できない問題を修正

## 内容
- 消費・廃棄登録の登録ボタンがフッターで隠れてしまい、登録できない
- 食材登録の次へボタンがフッターで隠れてしまい、ボタンが押せない
- 上記の問題はボタンのCSSを`fixed`->`sticky`に修正