### PR TITLE
食材名の検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "image_processing", "~> 1.2"
 
 gem "aws-sdk-s3", require: false
 
+gem "ransack"
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,6 +262,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    ransack (4.3.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -377,6 +381,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
   rails-i18n (~> 7.0.0)
+  ransack
   rubocop-rails-omakase
   selenium-webdriver
   sprockets-rails

--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -7,7 +7,8 @@ class UserFoodsController < ApplicationController
 
   def new
     @categories = Category.custom_order
-    @foods = Food.user_foods(current_user).by_category(params[:category_id]).order(name: :asc)
+    @q = Food.user_foods(current_user).by_category(params[:category_id]).ransack(params[:q])
+    @foods = @q.result(distinct: true).order(name: :asc)
     @form = Form::UserFoodCollection.new(current_user, @foods)
   end
 

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -48,6 +48,6 @@ class Food < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    ["category_id", "created_at", "default_deadline", "id", "id_value", "name", "quantity", "unit", "updated_at", "user_id"]
+    [ "category_id", "created_at", "default_deadline", "id", "id_value", "name", "quantity", "unit", "updated_at", "user_id" ]
   end
 end

--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -46,4 +46,8 @@ class Food < ApplicationRecord
       errors.add(:base, ":5MB以下のファイルをアップロードしてください。")
     end
   end
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["category_id", "created_at", "default_deadline", "id", "id_value", "name", "quantity", "unit", "updated_at", "user_id"]
+  end
 end

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -19,6 +19,6 @@
         <span class="text-xs font-medium">(準備中)</span>
       <% end %>
     </nav>
-    <p class="text-center text-xs text-gray-500"><%= t('footer.copyright', year: Time.current.year, app_name: 'FridgeBell') %></P>
+    <p class="text-center text-xs text-gray-500"><%= t('.copyright', year: Time.current.year, app_name: 'FridgeBell') %></P>
   </div>
 </footer>

--- a/app/views/shared/_how_to.html.erb
+++ b/app/views/shared/_how_to.html.erb
@@ -39,7 +39,7 @@
     </div>
     <p class="text-sm text-gray-600 text-center">
       <%= t('.user_foods_index_description1') %><br>
-      <%= t('.user_foods_index_description1') %>
+      <%= t('.user_foods_index_description2') %>
     </p>
   </div>
 

--- a/app/views/user_foods/_search.html.erb
+++ b/app/views/user_foods/_search.html.erb
@@ -1,8 +1,18 @@
 <%= search_form_for @q, url: url do |f| %>
-  <div class="flex justify-center mt-4">
-    <div class="flex items-center gap-2 w-full max-w-md">
-      <%= f.search_field :name_cont, class: "flex-1 px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-400", placeholder: "食材名" %>
-      <%= f.submit "検索", class: "px-4 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 shadow-sm" %>
+  <div class="flex justify-center mx-4 mt-2">
+    <%= hidden_field_tag :category_id, params[:category_id] %>
+    <div class="relative flex-1 max-w-md">
+      <%= f.search_field :name_cont, class: "w-full pl-10 pr-12 py-2 rounded-full border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-300", placeholder: "食材を検索" %>
+
+      <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+        <%= heroicon "magnifying-glass", options: { class: "w-5 h-5" } %>
+      </span>
+
+      <%= link_to new_user_food_path(category_id: params[:category_id]), class:"absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-500 cursor-pointer z-10" do %>
+        <%= heroicon "x-circle",  variant: :outline, options: { class: "w-6 h-6 text-gray-400"} %>
+      <% end %>
     </div>
+
+    <%= f.submit "検索", class: "ml-2 px-4 py-2 rounded-full text-center text-white bg-orange-500 hover:bg-orange-600 shadow-sm whitespace-nowrap min-w-[84px]" %>
   </div>
 <% end %>

--- a/app/views/user_foods/_search.html.erb
+++ b/app/views/user_foods/_search.html.erb
@@ -1,0 +1,8 @@
+<%= search_form_for @q, url: url do |f| %>
+  <div class="flex justify-center mt-4">
+    <div class="flex items-center gap-2 w-full max-w-md">
+      <%= f.search_field :name_cont, class: "flex-1 px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-400", placeholder: "食材名" %>
+      <%= f.submit "検索", class: "px-4 py-2 bg-orange-400 text-white rounded-lg hover:bg-orange-500 shadow-sm" %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/user_foods/_search.html.erb
+++ b/app/views/user_foods/_search.html.erb
@@ -2,7 +2,7 @@
   <div class="flex justify-center mx-4 mt-2">
     <%= hidden_field_tag :category_id, params[:category_id] %>
     <div class="relative flex-1 max-w-md">
-      <%= f.search_field :name_cont, class: "w-full pl-10 pr-12 py-2 rounded-full border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-300", placeholder: "食材を検索" %>
+      <%= f.search_field :name_cont, class: "w-full pl-10 pr-12 py-2 rounded-full border border-gray-300 shadow-sm focus:outline-none focus:ring-2 focus:ring-orange-300", placeholder: t('.placeholders.search_form') %>
 
       <span class="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
         <%= heroicon "magnifying-glass", options: { class: "w-5 h-5" } %>
@@ -13,6 +13,6 @@
       <% end %>
     </div>
 
-    <%= f.submit "検索", class: "ml-2 px-4 py-2 rounded-full text-center text-white bg-orange-500 hover:bg-orange-600 shadow-sm whitespace-nowrap min-w-[84px]" %>
+    <%= f.submit t('.search'), class: "ml-2 px-4 py-2 rounded-full text-center text-white bg-orange-500 hover:bg-orange-600 shadow-sm whitespace-nowrap min-w-[84px]" %>
   </div>
 <% end %>

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -20,6 +20,8 @@
         <div class="border-b border-gray-100">
           <%= render 'categories/category_nav', categories: @categories %>
         </div>
+        
+        <%= render 'search', q: @q, url: user_foods_path %>
 
         <div class="mx-4">
           <%= render "new_form", foods: @foods, user_food: @user_food %>

--- a/app/views/user_foods/new.html.erb
+++ b/app/views/user_foods/new.html.erb
@@ -20,8 +20,8 @@
         <div class="border-b border-gray-100">
           <%= render 'categories/category_nav', categories: @categories %>
         </div>
-        
-        <%= render 'search', q: @q, url: user_foods_path %>
+
+        <%= render 'search', q: @q, url: new_user_food_path(category_id: params[:category_id]) %>
 
         <div class="mx-4">
           <%= render "new_form", foods: @foods, user_food: @user_food %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -132,7 +132,11 @@ ja:
       how_many_days: "あと%{deadline_days}日"
       deadline: 期限
       quantity: 数量
-      mini_memo: メモ    
+      mini_memo: メモ
+    search:
+      search: 検索
+      placeholders:
+        search_form: 食材を検索   
   food_actions:
     form:
       title: 食材を選択し、数量を入力してください

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -45,6 +45,8 @@ ja:
       privacy_policy: プライバシーポリシー(準備中)
       contact_us: お問い合わせ(準備中)
       copyright: © %{year} %{app_name}
+    footer:
+      copyright: © %{year} %{app_name}
   homes:
     top:
       title: FridgeBell


### PR DESCRIPTION
## 概要
- i18n化
- 食材登録ページに食材名の検索機能を追加

## 内容
- gem `ransack`インストール
- `user_foods/_search.html.erb`に検索フォーム(`search_form`)を設置
- `food.rb`に検索対象とする属名を定義
- `user_foods#new`に検索結果を返すメソッド定義
- i18n化(how_toの食材一覧, ログイン後のfooter, 検索フォーム)

#### ISSUE番号
closed #33 