### PR TITLE
「+」「-」ボタンは1カウントあたりの数量に設定

### DIFF
--- a/app/controllers/user_foods_controller.rb
+++ b/app/controllers/user_foods_controller.rb
@@ -24,7 +24,8 @@ class UserFoodsController < ApplicationController
       ]
     else
       @categories = Category.custom_order
-      @foods = Food.user_foods(current_user).by_category(params[:category_id]).order(name: :asc)
+      @q = Food.user_foods(current_user).by_category(params[:category_id]).ransack(params[:q])
+      @foods = @q.result(distinct: true).order(name: :asc)
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/javascript/controllers/counter_controller.js
+++ b/app/javascript/controllers/counter_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="counter"
 export default class extends Controller {
-  static targets = ["output", "unit"]
+  static targets = ["output", "unit", "pretend"]
 
   connect(){
   }
@@ -16,8 +16,7 @@ export default class extends Controller {
     if (this.countValue < 100){
       const unit = Number(this.unitTarget.value);
       this.countValue += unit;
-      this.outputTarget.value = this.countValue;
-      this.outputTarget.dispatchEvent(new Event("input", { bubbles: true }));
+      this.render();
     }
   }
 
@@ -25,8 +24,13 @@ export default class extends Controller {
     if (this.countValue > 0){
       const unit = Number(this.unitTarget.value);
       this.countValue -= unit;
-      this.outputTarget.value = this.countValue;
-      this.outputTarget.dispatchEvent(new Event("input", { bubbles: true }));
+      this.render();
     }
+  }
+
+  render(){
+    this.pretendTarget.textContent = this.countValue;
+    this.outputTarget.value = this.countValue;
+    this.outputTarget.dispatchEvent(new Event("input", { bubbles: true }));
   }
 }

--- a/app/javascript/controllers/counter_controller.js
+++ b/app/javascript/controllers/counter_controller.js
@@ -2,9 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="counter"
 export default class extends Controller {
-  static targets = ["output"]
+  static targets = ["output", "unit"]
 
-  connect() {
+  connect(){
   }
 
   initialize(){
@@ -13,8 +13,9 @@ export default class extends Controller {
   }
 
   addition(){
-    if (this.countValue < 99){
-      this.countValue++;
+    if (this.countValue < 100){
+      const unit = Number(this.unitTarget.value);
+      this.countValue += unit;
       this.outputTarget.value = this.countValue;
       this.outputTarget.dispatchEvent(new Event("input", { bubbles: true }));
     }
@@ -22,7 +23,8 @@ export default class extends Controller {
 
   subtraction(){
     if (this.countValue > 0){
-      this.countValue--;
+      const unit = Number(this.unitTarget.value);
+      this.countValue -= unit;
       this.outputTarget.value = this.countValue;
       this.outputTarget.dispatchEvent(new Event("input", { bubbles: true }));
     }

--- a/app/models/form/user_food_collection.rb
+++ b/app/models/form/user_food_collection.rb
@@ -42,6 +42,9 @@ class Form::UserFoodCollection < Form::Base
         if rows.key?([ ruf.food_id, ruf.deadline_date ])
           existing = rows[[ ruf.food_id, ruf.deadline_date ]]
           sum = existing.quantity + ruf.quantity.to_f
+          if sum > 100
+            errors.add(:base, :quantity_max_one_hundred)
+          end
           existing.update!(quantity: sum)
         else
           ruf.save!

--- a/app/models/form/user_food_collection.rb
+++ b/app/models/form/user_food_collection.rb
@@ -22,7 +22,7 @@ class Form::UserFoodCollection < Form::Base
 
   def select_user_foods
     # quantity>0の食材を取得
-    self.user_foods.select { |uf| (uf.quantity || 0).to_i > 0 }
+    self.user_foods.select { |uf| (uf.quantity || 0).to_f > 0 }
   end
 
 
@@ -41,7 +41,7 @@ class Form::UserFoodCollection < Form::Base
         # 新規または期限が異なる場合は新規登録
         if rows.key?([ ruf.food_id, ruf.deadline_date ])
           existing = rows[[ ruf.food_id, ruf.deadline_date ]]
-          sum = existing.quantity + ruf.quantity.to_i
+          sum = existing.quantity + ruf.quantity.to_f
           existing.update!(quantity: sum)
         else
           ruf.save!

--- a/app/views/food_actions/_form.html.erb
+++ b/app/views/food_actions/_form.html.erb
@@ -65,7 +65,7 @@
               </div>
               <div class="text-sm text-gray-600">
                 <%= f.label :quantity %>:
-                <%= f.number_field :quantity, value: (fa.quantity || user_food.quantity), max: user_food.quantity, min: 1, class: "w-14 md:w-16 mx-1 border rounded px-2 py-1" %><%= user_food.food.unit %>
+                <%= f.number_field :quantity, value: (fa.quantity || user_food.quantity), max: user_food.quantity, min: user_food.food.quantity, step: 0.01, class: "w-14 md:w-16 mx-1 border rounded px-2 py-1" %><%= user_food.food.unit %>
               </div>
               <% if user_food.mini_memo.present? %>
                 <div class="text-sm text-gray-700">

--- a/app/views/food_actions/_form.html.erb
+++ b/app/views/food_actions/_form.html.erb
@@ -65,7 +65,7 @@
               </div>
               <div class="text-sm text-gray-600">
                 <%= f.label :quantity %>:
-                <%= f.number_field :quantity, value: (fa.quantity || user_food.quantity), max: user_food.quantity, min: user_food.food.quantity, step: 0.01, class: "w-14 md:w-16 mx-1 border rounded px-2 py-1" %><%= user_food.food.unit %>
+                <%= f.number_field :quantity, value: (fa.quantity || user_food.quantity), max: user_food.quantity, min: user_food.food.quantity, step: user_food.food.quantity, class: "w-14 md:w-16 mx-1 border rounded px-2 py-1" %><%= user_food.food.unit %>
               </div>
               <% if user_food.mini_memo.present? %>
                 <div class="text-sm text-gray-700">

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -40,14 +40,20 @@
             <div class="flex flex-col items-center gap-2">
 
               <div data-controller="counter" class="flex items-center  gap-2">
+                <%#= -ボタン %>
                 <button data-action="click->counter#subtraction" type="button" class="border-2 border-blue-300 text-blue-500 rounded-lg p-2 hover:border-2 hover:border-blue-400 hover:text-blue-600">
                   <%= heroicon "minus", options: { class: "w-10 h-10 sm:w-5 sm:h-5"} %>
                 </button>
-
+                
+                <%#= 食材1カウントあたりの数量 %>
                 <input type="hidden" data-counter-target="unit" value="<%= food.quantity %>">
+                
+                <%# 見せかけのフォーム %>
+                <span data-counter-target="pretend" class= "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-8 sm:py-2 shadow-inner">0</span>
 
-                <%= f.number_field :quantity, min: 0, step: 0.01, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" }, class: "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-2 shadow-inner" %>
+                <%= f.hidden_field :quantity, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" } %>
 
+                 <%#= +ボタン %>
                 <button data-action="click->counter#addition" type="button" class="border-2 border-red-300 rounded-lg text-red-500 p-2 hover:border-2 hover:border-red-400 hover:text-red-600">
                   <%= heroicon "plus", options: { class: "w-10 h-10 sm:w-5 sm:h-5"} %>
                 </button>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -48,8 +48,8 @@
                 <%#= 食材1カウントあたりの数量 %>
                 <input type="hidden" data-counter-target="unit" value="<%= food.quantity %>">
                 
-                <%# 見せかけのフォーム %>
-                <span data-counter-target="pretend" class= "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-8 sm:py-2 shadow-inner">0</span>
+                <%# カウントの反映 %>
+                <span data-counter-target="pretend" class= "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-8 sm:py-2 shadow-inner">0</span>
 
                 <%= f.hidden_field :quantity, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" } %>
 

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -44,7 +44,9 @@
                   <%= heroicon "minus", options: { class: "w-10 h-10 sm:w-5 sm:h-5"} %>
                 </button>
 
-                <%= f.number_field :quantity, min: 0, step: 1, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" }, class: "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-2 shadow-inner" %>
+                <input type="hidden" data-counter-target="unit" value="<%= food.quantity %>">
+
+                <%= f.number_field :quantity, min: 0, step: 0.01, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" }, class: "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-2 shadow-inner" %>
 
                 <button data-action="click->counter#addition" type="button" class="border-2 border-red-300 rounded-lg text-red-500 p-2 hover:border-2 hover:border-red-400 hover:text-red-600">
                   <%= heroicon "plus", options: { class: "w-10 h-10 sm:w-5 sm:h-5"} %>

--- a/app/views/user_foods/_new_form.html.erb
+++ b/app/views/user_foods/_new_form.html.erb
@@ -49,7 +49,7 @@
                 <input type="hidden" data-counter-target="unit" value="<%= food.quantity %>">
                 
                 <%# カウントの反映 %>
-                <span data-counter-target="pretend" class= "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-8 sm:py-2 shadow-inner">0</span>
+                <span data-counter-target="pretend" class= "w-20 sm:w-16 text-center border border-gray-300 rounded-lg px-3 py-4 sm:py-2 shadow-inner">0</span>
 
                 <%= f.hidden_field :quantity, data: { foods_selection_target: "quantity", counter_target: "output", index: i, action: "input->foods-selection#check" } %>
 

--- a/app/views/user_foods/_user_food.html.erb
+++ b/app/views/user_foods/_user_food.html.erb
@@ -43,7 +43,8 @@
       </div>
       <div class="text-sm text-gray-600">
         <%= t('.quantity') %>: 
-        <%= user_food.quantity %><%= user_food.food.unit %>
+        <%= number_with_precision(user_food.quantity, precision: 2, strip_insignificant_zeros: true) %>
+        <%= user_food.food.unit %>
       </div>
       <% if user_food.mini_memo.present? %>
         <div class="text-sm text-gray-700">

--- a/app/views/user_foods/edit.html.erb
+++ b/app/views/user_foods/edit.html.erb
@@ -36,7 +36,7 @@
             <div class="flex flex-wrap md:flex-nowrap gap-4 items-start">
               <div class="w-20">
                 <%= f.label :quantity, class: "block font-medium text-gray-700 mb-1" %>
-                <%= f.number_field :quantity, min: 1, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm" %>
+                <%= f.number_field :quantity, min: @user_food.food.quantity, step: 0.01, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm" %>
               </div>
               <div class="flex-1">
                 <%= f.label :deadline_date, class: "block font-medium text-gray-700 mb-1" %>

--- a/app/views/user_foods/edit.html.erb
+++ b/app/views/user_foods/edit.html.erb
@@ -36,7 +36,7 @@
             <div class="flex flex-wrap md:flex-nowrap gap-4 items-start">
               <div class="w-20">
                 <%= f.label :quantity, class: "block font-medium text-gray-700 mb-1" %>
-                <%= f.number_field :quantity, min: @user_food.food.quantity, step: 0.01, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm" %>
+                <%= f.number_field :quantity, min: @user_food.food.quantity, step: @user_food.food.quantity, class: "w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm" %>
               </div>
               <div class="flex-1">
                 <%= f.label :deadline_date, class: "block font-medium text-gray-700 mb-1" %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,6 +10,7 @@ ja:
           attributes:
             base:
               quantity_required_message: 登録する食材の数量を入力してください
+              quantity_max_one_hundred: 上限（100）を超えています。数量を減らしてください。
   activerecord:
     models:
       user: ユーザー


### PR DESCRIPTION
## 概要
- 食材登録画面の「+」「-」ボタンは1カウントあたりの数量に修正
- `user_foods/edit.html.erb`, `food_actions/_form.html.erb`の`quantity`フォームのオプション修正
- `user_foods#index`の食材の数量は小数点以下の0は削除して表示
- 冷蔵庫の食材+登録する食材が100を超えていたらエラー

## 内容
- 食材登録画面の「+」「-」ボタンは1カウントあたりの数量に修正
  - `user_food.quantity`+=`food.quantity`
  - `user_food.quantity`は`f.number_field`->`f.hidden_field`に変更
  - ボタンのみで食材の数量をカウントする
 - `user_foods/edit.html.erb`, `food_actions/_form.html.erb`の`quantity`フォームのオプション修正
   - `f.number_field`のmin, step は`food.quantity`
 - `user_foods#index`の食材の数量は小数点以下の0は削除して表示
   - `number_with_precision`で小数以下の桁数: 2, 小数点以下の0を削除のオプション設定
 - 冷蔵庫の食材+登録する食材が100を超えていたらエラー
   - `form/user_food_collerction.rb`に条件式とエラーを追記
  
#### ISSUE番号
closed #118 