### PR TITLE
Reminderモデル, Remindersテーブル作成

### DIFF
--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,0 +1,2 @@
+class Reminder < ApplicationRecord
+end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,2 +1,3 @@
 class Reminder < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,3 +1,6 @@
 class Reminder < ApplicationRecord
   belongs_to :user
+
+  validates :user_id, :remind_time, presence: true
+  validates :days_before, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 30 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   has_many :user_foods, dependent: :destroy
   has_many :food_actions, dependent: :destroy
   has_one :user_character, dependent: :destroy
+  has_one :reminder, dependent: :destroy
   after_create :set_user_character
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/db/migrate/20250917054915_create_reminders.rb
+++ b/db/migrate/20250917054915_create_reminders.rb
@@ -1,0 +1,11 @@
+class CreateReminders < ActiveRecord::Migration[7.2]
+  def change
+    create_table :reminders do |t|
+      t.references :user, foreign_key: true, null: false
+      t.integer :days_before, null: false
+      t.time :remind_time, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_10_093217) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_17_054915) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -85,6 +85,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_10_093217) do
     t.index ["user_id"], name: "index_foods_on_user_id"
   end
 
+  create_table "reminders", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "days_before", null: false
+    t.time "remind_time", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_reminders_on_user_id"
+  end
+
   create_table "user_characters", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "character_id", null: false
@@ -129,6 +138,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_10_093217) do
   add_foreign_key "food_actions", "users"
   add_foreign_key "foods", "categories"
   add_foreign_key "foods", "users"
+  add_foreign_key "reminders", "users"
   add_foreign_key "user_characters", "characters"
   add_foreign_key "user_characters", "users"
   add_foreign_key "user_foods", "foods"

--- a/test/fixtures/reminders.yml
+++ b/test/fixtures/reminders.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  days_before: 1
+  remind_time: 2025-09-17 14:49:15
+
+two:
+  days_before: 1
+  remind_time: 2025-09-17 14:49:15

--- a/test/models/reminder_test.rb
+++ b/test/models/reminder_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReminderTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
- Reminderモデル作成
- Remindersテーブル作成
- Userモデル, Reminderモデルにアソシエーション定義
- Reminderモデルにバリデーション定義

## 内容
- Remindersテーブル作成
  - `user_id`, `days_before(integer)`, `remind_time(time)`カラム
- Userモデル, Reminderモデルにアソシエーション定義
  - `1対1`の関係（Userモデル: `has_one`, Reminderモデル: `belongs_to`）
- Reminderモデルにバリデーション定義
  - `user_id`, `remind_time`: 必須
  - `days_before`: 必須, 0以上30以下の整数

#### ISSUE番号
closed #138   