### PR TITLE
リマインド設定(new, create, show)

### DIFF
--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -5,6 +5,7 @@ class RemindersController < ApplicationController
   end
 
   def new
+    @reminder = Reminder.new
   end
 
   def create

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -2,6 +2,7 @@ class RemindersController < ApplicationController
   before_action :authenticate_user!
 
   def show
+    @reminder = current_user.reminder
   end
 
   def new
@@ -9,5 +10,17 @@ class RemindersController < ApplicationController
   end
 
   def create
+    @reminder = current_user.build_reminder(reminder_params)
+    if @reminder.save
+      redirect_to reminder_path, notice: "リマインド設定が完了しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def reminder_params
+    params.require(:reminder).permit(:user_id, :days_before, :remind_time)
   end
 end

--- a/app/controllers/reminders_controller.rb
+++ b/app/controllers/reminders_controller.rb
@@ -1,0 +1,12 @@
+class RemindersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+  end
+
+  def new
+  end
+
+  def create
+  end
+end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,6 +1,7 @@
 class Reminder < ApplicationRecord
   belongs_to :user
 
-  validates :user_id, :remind_time, presence: true
+  validates :user_id, presence: true, uniqueness: true
   validates :days_before, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 30 }
+  validates :remind_time, presence: true
 end

--- a/app/views/reminders/new.html.erb
+++ b/app/views/reminders/new.html.erb
@@ -1,0 +1,37 @@
+<main class="flex-1 md:px-8">
+  <div class="mx-auto max-w-xl md:max-w-7xl">
+    <div class="min-h-screen flex justify-center items-start mb-6">
+      <div class="bg-white mx-4 py-4 px-8 md:my-6 shadow-sm border border-gray-100 rounded-2xl w-full max-w-md font-mono">
+
+        <div class="text-center">
+          <h1 class="text-2xl font-medium tracking-tight text-gray-700">
+            リマインド設定
+          </h1>
+        </div>
+
+        <%= form_with model: @reminder, url: reminder_path, html: { class: "" } do |f| %>
+          <%= render "shared/error_messages", object: f.object %>
+
+          <div>
+            <%= f.label :days_before, class: "block mt-4 mb-1 text-left text-sm font-semibold text-gray-700" %>
+            <span class="text-sm text-gray-700">期限切れ</span>
+            <%= f.number_field :days_before, class: "w-1/4 mb-2 rounded-lg border border-gray-400 bg-white/80 px-4 py-2 text-sm text-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-300 focus:ring-offset-2 focus:ring-offset-white", placeholder: "例) 2" %>
+            <span class="text-sm text-gray-700">日前に通知</span>
+          </div>
+
+          <div>
+            <%= f.label :remind_time, class: "block mt-4 mb-1 text-left text-sm font-semibold text-gray-700" %>
+            <%= f.time_select :remind_time, 
+                {
+                  minute_step: 15,
+                  prompt: { hour: '時', minute: '分' }
+                },
+                class: "mb-2 rounded-lg border border-gray-400 bg-white/80 px-4 py-2 text-sm text-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-gray-300 focus:ring-offset-2 focus:ring-offset-white" %>
+          </div>
+
+          <%= f.submit "登録", class: "w-full mt-2 bg-orange-400 hover:bg-orange-500 text-white font-semibold py-4 text-sm rounded-xl shadow-lg hover:shadow-xl transition-all duration-200" %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/reminders/show.html.erb
+++ b/app/views/reminders/show.html.erb
@@ -1,0 +1,42 @@
+<main class="flex-1 md:px-8">
+  <div class="mx-auto max-w-xl md:max-w-7xl">
+    <div class="flex justify-center items-start mb-6">
+      <div class="bg-white mx-4 py-4 px-8 md:my-6 shadow-sm border border-gray-100 rounded-2xl w-full max-w-md font-mono">
+
+        <div class="text-center">
+          <h1 class="flex items-center justify-center gap-2 text-xl md:text-2xl font-semibold tracking-tight text-gray-800">
+            <%= heroicon "bell-alert", variant: :outline, options: { class: "w-6 h-6 inline-block shrink-0" } %>
+            リマインド設定
+          </h1>
+        </div>
+        
+        <% if @reminder.present? %>
+          <div>
+            <p class="mt-4 mb-1 text-xs font-semibold tracking-wider text-gray-500">
+              リマインド
+            </p>
+            <span class="text-base md:text-lg font-medium text-gray-800 tabular-nums">
+              期限切れ<%= @reminder.days_before %>日前に通知
+            </span>
+          </div>
+
+          <div>
+            <p class="mt-6 mb-1 text-xs font-semibold tracking-wider text-gray-500">
+              通知時刻
+            </p>
+            <div class="text-base md:text-lg font-medium text-gray-800 tabular-nums">
+              <%= @reminder.remind_time.strftime("%-H時%M分") %>
+            </div>
+          </div>
+
+        <% else %>
+          <div class="mt-4 mb-1 text-xs font-semibold text-gray-700 text-center">
+            <p class="block">食材の期限が切れる前に通知を受け取ろう！</p>
+            <%= link_to "リマインドを設定する", new_reminder_path, class: "inline-flex items-center mt-2 px-5 py-2.5 rounded-xl bg-gradient-to-r from-orange-400 to-pink-400 text-white font-semibold shadow-sm hover:shadow-md hover:from-orange-500 hover:to-pink-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-300 transition" %>
+          </div>
+        <% end %>
+
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -30,7 +30,10 @@
         <span class="text-xs font-medium">Add Item</span>
       <% end %>
 
-      <%= link_to "#", class: "flex flex-col items-center text-gray-300 space-y-1 px-4 py-2 rounded-2xl" do %>
+      <%= link_to reminder_path, class: "#{item_base}
+          #{ current_page?(reminder_path) ?
+            'bg-orange-100 text-orange-600' :
+            'hover:bg-gray-100 text-gray-300 transition-colors' }" do %>
         <%= heroicon "bell-alert", variant: :outline, options: { class: "w-6 h-6" } %>
         <span class="text-xs font-medium">準備中</span> 
       <% end %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -18,6 +18,7 @@ ja:
       food: 食材
       user_food: 登録食材
       food_action: 消費・廃棄
+      reminder: リマインド
     errors:
       models:
         food:
@@ -54,3 +55,6 @@ ja:
         action_types:
           consumed: 消費
           discarded: 廃棄
+      reminder:
+        days_before: リマインド
+        remind_time: 通知時刻

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     resource :consume, only: %i[new create]
     resource :discard, only: %i[new create]
   end
+  resource :reminder, only: %i[show new create]
   get "character_stage", to: "user_characters#character_stage"
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/db/migrate/20250917094733_add_unique_index_to_reminders_user_id.rb
+++ b/db/migrate/20250917094733_add_unique_index_to_reminders_user_id.rb
@@ -1,0 +1,6 @@
+class AddUniqueIndexToRemindersUserId < ActiveRecord::Migration[7.2]
+  def change
+    remove_index :reminders, name: "index_reminders_on_user_id"
+    add_index :reminders, :user_id, unique: true, name: "index_reminders_on_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_17_054915) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_17_094733) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,7 +91,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_17_054915) do
     t.time "remind_time", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_reminders_on_user_id"
+    t.index ["user_id"], name: "index_reminders_on_user_id", unique: true
   end
 
   create_table "user_characters", force: :cascade do |t|


### PR DESCRIPTION
## 概要
リマインド設定のnew, create, showアクションとviewを作成

## 内容
- ルーティング定義(`new`, `create`, `show`)
- `reminders_controller`作成
- `new`, `create`, `show`アクション定義
- `new.html.erb`, `show.html.erb`作成・編集
- footerの「リマインド設定」のリンクを`reminder_path`に修正
- リマインド設定はユーザーと1：1になるようにバリデーションとユニークインデックスを追加
  - Reminderモデルに`uniqueness: true`のバリデーション追加
  - マイグレーションファイル作成し、`user_id`をユニークインデックスに編集

#### ISSUE番号
closed #137 