### PR TITLE
food_actionsテーブルにカラム追加、バリデーション定義、アソシエーション変更

### DIFF
--- a/app/models/food_action.rb
+++ b/app/models/food_action.rb
@@ -3,7 +3,7 @@ class FoodAction < ApplicationRecord
   belongs_to :user_food, optional: true
   enum :action_type, { consumed: 0, discarded: 1 }, validate: true
 
-  validates :user_id, :user_food_id, :action_type, :action_date, :quantity, :food_name, :unit, presence: true
+  validates :user_id, :user_food_id, :action_type, :action_date, :quantity, presence: true
   validates :quantity, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
   validates :availability, inclusion: { in: [ true, false ] }
   validates :food_name, length: { maximum: 15 }

--- a/app/models/food_action.rb
+++ b/app/models/food_action.rb
@@ -1,6 +1,6 @@
 class FoodAction < ApplicationRecord
   belongs_to :user
-  belongs_to :user_food
+  belongs_to :user_food, optional: true
   enum :action_type, { consumed: 0, discarded: 1 }, validate: true
 
   validates :user_id, :user_food_id, :action_type, :action_date, :quantity, :food_name, :unit, presence: true

--- a/app/models/food_action.rb
+++ b/app/models/food_action.rb
@@ -3,7 +3,9 @@ class FoodAction < ApplicationRecord
   belongs_to :user_food
   enum :action_type, { consumed: 0, discarded: 1 }, validate: true
 
-  validates :user_id, :user_food_id, :action_type, :action_date, :quantity, presence: true
+  validates :user_id, :user_food_id, :action_type, :action_date, :quantity, :food_name, :unit, presence: true
   validates :quantity, numericality: { greater_than: 0, less_than_or_equal_to: 100 }
   validates :availability, inclusion: { in: [ true, false ] }
+  validates :food_name, length: { maximum: 15 }
+  validates :unit, length: { maximum: 5 }
 end

--- a/app/models/user_food.rb
+++ b/app/models/user_food.rb
@@ -1,7 +1,7 @@
 class UserFood < ApplicationRecord
   belongs_to :user
   belongs_to :food
-  has_many :food_actions, dependent: :destroy
+  has_many :food_actions, dependent: :nullify
 
   validates :user_id, :food_id, :deadline_date, presence: true
   validates :quantity, presence: true, numericality: { greater_than: 0, less_than_or_equal_to: 100 }

--- a/db/migrate/20250927094452_add_food_name_and_unit_to_food_actions.rb
+++ b/db/migrate/20250927094452_add_food_name_and_unit_to_food_actions.rb
@@ -1,0 +1,6 @@
+class AddFoodNameAndUnitToFoodActions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :food_actions, :food_name, :string
+    add_column :food_actions, :unit, :string
+  end
+end

--- a/db/migrate/20250927103220_change_column_null_user_food_id_to_food_actions.rb
+++ b/db/migrate/20250927103220_change_column_null_user_food_id_to_food_actions.rb
@@ -1,0 +1,5 @@
+class ChangeColumnNullUserFoodIdToFoodActions < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :food_actions, :user_food_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_17_094733) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_27_094452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -65,6 +65,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_17_094733) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "availability", default: false, null: false
+    t.string "food_name"
+    t.string "unit"
     t.index ["user_food_id"], name: "index_food_actions_on_user_food_id"
     t.index ["user_id"], name: "index_food_actions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_27_094452) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_27_103220) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -58,7 +58,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_27_094452) do
 
   create_table "food_actions", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "user_food_id", null: false
+    t.bigint "user_food_id"
     t.integer "action_type", null: false
     t.datetime "action_date", null: false
     t.float "quantity", null: false


### PR DESCRIPTION
## 概要
- food_actionsテーブルにカラム追加, null許可
- バリデーション定義
- アソシエーション変更

## 内容
- food_actionsテーブルにカラム追加, null許可
  - `food_name`(string), `unit`(string)
  - `user_food_id`の`null: false` -> `null: true`
- バリデーション定義
  - Foodモデルの`name`, `unit`のバリデーションと揃える(presence: true以外)
- アソシエーション変更
  - UserFoodモデル： `dependent: :destroy`->`dependent: :nullify`変更
  - FoodActionモデル：` optional: true`追加
 
#### ISSUE番号
closed #169 